### PR TITLE
Add layout helpers for Elementor containers and rebuild Admin_Settings rendering

### DIFF
--- a/src/admin/helper/class-block-builder.php
+++ b/src/admin/helper/class-block-builder.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Helper for building block markup with wrapper elements.
+ *
+ * @package Progressus\Gutenberg
+ */
+
+namespace Progressus\Gutenberg\Admin\Helper;
+
+use function esc_attr;
+use function sanitize_html_class;
+use function wp_json_encode;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Helper for building block markup with wrapper elements.
+ */
+class Block_Builder {
+	/**
+	 * Blocks that require wrapper div output.
+	 *
+	 * @var array<string>
+	 */
+	private static $wrapper_blocks = array( 'group', 'columns', 'column' );
+
+	/**
+	 * Build the serialized markup for a block including wrapper markup when required.
+	 *
+	 * @param string $block      Block name without `core/` prefix (e.g. `group`).
+	 * @param array  $attrs      Attributes array to encode in block comment.
+	 * @param string $inner_html Inner HTML for the block.
+	 *
+	 * @return string
+	 */
+	public static function build( string $block, array $attrs, string $inner_html ): string {
+		$attr_json = '';
+		if ( ! empty( $attrs ) ) {
+			$attr_json = ' ' . wp_json_encode( $attrs );
+		}
+
+		$opening_comment = sprintf( '<!-- wp:%s%s -->', $block, $attr_json );
+		$closing_comment = sprintf( '<!-- /wp:%s -->', $block );
+
+		if ( in_array( $block, self::$wrapper_blocks, true ) ) {
+			$wrapper_class = self::build_wrapper_class( $block, $attrs );
+			$style_attr    = self::build_style_attribute( $attrs );
+
+			$wrapper = sprintf(
+				'<div class="%s"%s>%s</div>',
+				esc_attr( $wrapper_class ),
+				$style_attr,
+				$inner_html
+			);
+
+			return $opening_comment . $wrapper . $closing_comment . "\n";
+		}
+
+		return $opening_comment . $inner_html . $closing_comment . "\n";
+	}
+
+	/**
+	 * Build the wrapper class attribute from block attributes.
+	 *
+	 * @param string $block Block name.
+	 * @param array  $attrs Block attributes.
+	 *
+	 * @return string
+	 */
+	private static function build_wrapper_class( string $block, array $attrs ): string {
+		$classes   = array( 'wp-block-' . $block );
+		$align     = isset( $attrs['align'] ) ? trim( (string) $attrs['align'] ) : '';
+		$class_raw = isset( $attrs['className'] ) ? (string) $attrs['className'] : '';
+
+		if ( '' !== $align ) {
+			$classes[] = 'align' . sanitize_html_class( $align );
+		}
+
+		if ( '' !== $class_raw ) {
+			$class_parts = preg_split( '/\s+/', $class_raw );
+			if ( is_array( $class_parts ) ) {
+				foreach ( $class_parts as $class_part ) {
+					$class_part = trim( $class_part );
+					if ( '' !== $class_part ) {
+						$classes[] = sanitize_html_class( $class_part );
+					}
+				}
+			}
+		}
+
+		return implode( ' ', array_filter( $classes ) );
+	}
+
+	/**
+	 * Build inline style attribute for wrapper blocks.
+	 *
+	 * @param array $attrs Block attributes.
+	 *
+	 * @return string
+	 */
+	private static function build_style_attribute( array $attrs ): string {
+		if ( empty( $attrs['style'] ) || ! is_array( $attrs['style'] ) ) {
+			return '';
+		}
+
+		$styles = array();
+		$style  = $attrs['style'];
+
+		if ( isset( $style['spacing']['blockGap'] ) ) {
+			$styles[] = 'gap:' . self::normalize_style_value( $style['spacing']['blockGap'] );
+		}
+
+		foreach ( array( 'padding', 'margin' ) as $box_type ) {
+			if ( empty( $style['spacing'][ $box_type ] ) || ! is_array( $style['spacing'][ $box_type ] ) ) {
+				continue;
+			}
+
+			foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
+				if ( ! isset( $style['spacing'][ $box_type ][ $side ] ) ) {
+					continue;
+				}
+
+				$value = $style['spacing'][ $box_type ][ $side ];
+				if ( '' === $value ) {
+					continue;
+				}
+
+				$styles[] = sprintf(
+					'%s-%s:%s',
+					$box_type,
+					$side,
+					self::normalize_style_value( $value )
+				);
+			}
+		}
+
+		if ( isset( $style['color']['background'] ) && '' !== $style['color']['background'] ) {
+			$styles[] = 'background-color:' . self::normalize_style_value( $style['color']['background'] );
+		}
+
+		if ( empty( $styles ) ) {
+			return '';
+		}
+
+		return ' style="' . esc_attr( implode( ';', $styles ) ) . '"';
+	}
+
+	/**
+	 * Normalize style values for inline usage (e.g. presets to CSS vars).
+	 *
+	 * @param string $value Raw value from attributes.
+	 *
+	 * @return string
+	 */
+	private static function normalize_style_value( $value ): string {
+		$value = (string) $value;
+		if ( 0 === strpos( $value, 'var:' ) ) {
+			$without_prefix = substr( $value, 4 );
+			$parts          = explode( '|', $without_prefix );
+			if ( ! empty( $parts ) ) {
+				$value = 'var(--wp--' . implode( '--', array_map( 'sanitize_html_class', $parts ) ) . ')';
+			}
+		}
+
+		return $value;
+	}
+}

--- a/src/admin/helper/class-style-parser.php
+++ b/src/admin/helper/class-style-parser.php
@@ -4,6 +4,7 @@
  *
  * @package Progressus\Gutenberg
  */
+
 namespace Progressus\Gutenberg\Admin\Helper;
 
 defined( 'ABSPATH' ) || exit;
@@ -16,6 +17,7 @@ class Style_Parser {
 	 * Parse typography settings from Elementor settings.
 	 *
 	 * @param array $settings The Elementor settings array.
+	 *
 	 * @return array Array containing 'attributes' and 'style' keys.
 	 */
 	public static function parse_typography( array $settings ): array {
@@ -23,14 +25,14 @@ class Style_Parser {
 		$style = '';
 
 		$typography_fields = array(
-			'typography_font_family'     => array( 'attr' => 'fontFamily', 'style' => 'font-family' ),
-			'typography_font_size'       => array( 'attr' => 'fontSize', 'style' => 'font-size', 'is_array' => true ),
-			'typography_font_weight'     => array( 'attr' => 'fontWeight', 'style' => 'font-weight' ),
-			'typography_line_height'     => array( 'attr' => 'lineHeight', 'style' => 'line-height', 'is_array' => true ),
-			'typography_font_style'      => array( 'attr' => 'fontStyle', 'style' => 'font-style' ),
-			'typography_text_decoration' => array( 'attr' => 'textDecoration', 'style' => 'text-decoration' ),
-			'typography_letter_spacing'  => array( 'attr' => 'letterSpacing', 'style' => 'letter-spacing', 'is_array' => true ),
-			'typography_word_spacing'    => array( 'attr' => 'wordSpacing', 'style' => 'word-spacing', 'is_array' => true ),
+		'typography_font_family'     => array( 'attr' => 'fontFamily', 'style' => 'font-family' ),
+		'typography_font_size'       => array( 'attr' => 'fontSize', 'style' => 'font-size', 'is_array' => true ),
+		'typography_font_weight'     => array( 'attr' => 'fontWeight', 'style' => 'font-weight' ),
+		'typography_line_height'     => array( 'attr' => 'lineHeight', 'style' => 'line-height', 'is_array' => true ),
+		'typography_font_style'      => array( 'attr' => 'fontStyle', 'style' => 'font-style' ),
+		'typography_text_decoration' => array( 'attr' => 'textDecoration', 'style' => 'text-decoration' ),
+		'typography_letter_spacing'  => array( 'attr' => 'letterSpacing', 'style' => 'letter-spacing', 'is_array' => true ),
+		'typography_word_spacing'    => array( 'attr' => 'wordSpacing', 'style' => 'word-spacing', 'is_array' => true ),
 		);
 
 		foreach ( $typography_fields as $key => $field ) {
@@ -42,19 +44,19 @@ class Style_Parser {
 				$size = $settings[ $key ]['size'] ?? '';
 				$unit = $settings[ $key ]['unit'] ?? ( 'typography_line_height' === $key ? '' : 'px' );
 				if ( '' !== $size ) {
-					$value = $size . $unit;
+					$value                  = $size . $unit;
 					$attrs[ $field['attr'] ] = $value;
-					$style .= sprintf( '%s:%s;', $field['style'], esc_attr( $value ) );
+					$style                 .= sprintf( '%s:%s;', $field['style'], esc_attr( $value ) );
 				}
 			} else {
 				$attrs[ $field['attr'] ] = $settings[ $key ];
-				$style .= sprintf( '%s:%s;', $field['style'], esc_attr( $settings[ $key ] ) );
+				$style                 .= sprintf( '%s:%s;', $field['style'], esc_attr( $settings[ $key ] ) );
 			}
 		}
 
 		return array(
-			'attributes' => $attrs,
-			'style'      => $style,
+		'attributes' => $attrs,
+		'style'      => $style,
 		);
 	}
 
@@ -62,21 +64,87 @@ class Style_Parser {
 	 * Parse spacing settings from Elementor settings.
 	 *
 	 * @param array $settings The Elementor settings array.
+	 *
 	 * @return array Array containing style attributes for spacing.
 	 */
 	public static function parse_spacing( array $settings ): array {
-		$attrs = array( 'style' => array( 'spacing' => array() ) );
-		$spacing_types = array( 'margin', 'padding' );
+		$spacing = array();
 
-		foreach ( $spacing_types as $spacing ) {
-			$spacing_key = '_' . $spacing;
-			if ( ! isset( $settings[ $spacing_key ] ) || ! is_array( $settings[ $spacing_key ] ) ) {
+		foreach ( array( '_margin' => 'margin', 'margin' => 'margin', '_padding' => 'padding', 'padding' => 'padding' ) as $key => $type ) {
+			if ( empty( $settings[ $key ] ) || ! is_array( $settings[ $key ] ) ) {
 				continue;
 			}
 
+			$box      = $settings[ $key ];
+			$unit     = isset( $box['unit'] ) ? (string) $box['unit'] : 'px';
+			$unit     = '' === $unit ? 'px' : $unit;
+			$resolved = array();
+
 			foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
-				if ( isset( $settings[ $spacing_key ][ $side ] ) ) {
-					$attrs['style']['spacing'][ $spacing ][ $side ] = $settings[ $spacing_key ][ $side ] . ( $settings[ $spacing_key ]['unit'] ?? 'px' );
+				if ( ! isset( $box[ $side ] ) ) {
+					continue;
+				}
+
+				$value = self::resolve_dimension( $box[ $side ], $unit );
+				if ( '' !== $value ) {
+					$resolved[ $side ] = $value;
+				}
+			}
+
+			if ( ! empty( $resolved ) ) {
+				$spacing[ $type ] = $resolved;
+			}
+		}
+
+		$gap_keys = array( 'gap', 'gap_columns', 'column_gap' );
+		foreach ( $gap_keys as $gap_key ) {
+			if ( empty( $settings[ $gap_key ] ) ) {
+				continue;
+			}
+
+			$value = self::resolve_dimension( $settings[ $gap_key ], 'px' );
+			if ( '' !== $value ) {
+				$spacing['blockGap'] = $value;
+				break;
+			}
+		}
+
+		$result = array( 'style' => array() );
+		if ( ! empty( $spacing ) ) {
+			$result['style']['spacing'] = $spacing;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Parse border settings from Elementor settings.
+	 *
+	 * @param array $settings Elementor settings array.
+	 *
+	 * @return array
+	 */
+	public static function parse_border( array $settings ): array {
+		$attrs = array();
+
+		if ( isset( $settings['border_radius'] ) && is_array( $settings['border_radius'] ) ) {
+			$radius_unit = isset( $settings['border_radius']['unit'] ) ? $settings['border_radius']['unit'] : 'px';
+			foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
+				if ( isset( $settings['border_radius'][ $side ] ) ) {
+					$attrs['style']['border']['radius'][ $side ] = self::resolve_dimension( $settings['border_radius'][ $side ], $radius_unit );
+				}
+			}
+		}
+
+		if ( isset( $settings['border_border'] ) && '' !== $settings['border_border'] ) {
+			$attrs['style']['border']['style'] = $settings['border_border'];
+		}
+
+		if ( isset( $settings['border_width'] ) && is_array( $settings['border_width'] ) ) {
+			$width_unit = isset( $settings['border_width']['unit'] ) ? $settings['border_width']['unit'] : 'px';
+			foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
+				if ( isset( $settings['border_width'][ $side ] ) ) {
+					$attrs['style']['border']['width'][ $side ] = self::resolve_dimension( $settings['border_width'][ $side ], $width_unit );
 				}
 			}
 		}
@@ -84,30 +152,93 @@ class Style_Parser {
 		return $attrs;
 	}
 
-	public static function parse_border( array $settings ) {
-		if ( isset( $settings['border_radius'] ) && is_array( $settings['border_radius'] ) ) {
-			$unit = isset( $settings['border_radius']['unit'] ) ? $settings['border_radius']['unit'] : 'px';
-			foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
-				
-				if ( isset( $settings['border_radius'][ $side ] ) ) {
-					$attrs['style']['border']['radius'][ $side ] = $settings['border_radius'][ $side ] . $unit;
-				}
-			}
+	/**
+	 * Parse container styles to Gutenberg block attributes subset.
+	 *
+	 * @param array $settings Elementor settings array.
+	 *
+	 * @return array
+	 */
+	public static function parse_container_styles( array $settings ): array {
+		$attrs = array();
+		$style = array();
+
+		$spacing = self::parse_spacing( $settings );
+		if ( ! empty( $spacing['style']['spacing'] ) ) {
+			$style['spacing'] = $spacing['style']['spacing'];
 		}
 
-		if ( isset( $settings['border_border'] ) ) {
-			$attrs['style']['border']['style'] = $settings['border_border'];
+		$background = self::get_background_color( $settings );
+		if ( '' !== $background ) {
+			$style['color']['background'] = $background;
 		}
 
-		if ( isset( $settings['border_width'] ) && is_array( $settings['border_width'] ) ) {
-			$unit = isset( $settings['border_width']['unit'] ) ? $settings['border_width']['unit'] : 'px';
-			foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
-				if ( isset( $settings['border_width'][ $side ] ) ) {
-					$attrs['style']['border']['width'][ $side ] = $settings['border_width'][ $side ] . $unit;
-				}
-			}
+		if ( isset( $settings['css_classes'] ) && '' !== trim( (string) $settings['css_classes'] ) ) {
+			$attrs['className'] = trim( (string) $settings['css_classes'] );
+		}
+
+		if ( ! empty( $style ) ) {
+			$attrs['style'] = $style;
 		}
 
 		return $attrs;
+	}
+
+	/**
+	 * Resolve a dimension value to a CSS-ready string.
+	 *
+	 * @param mixed  $value Raw Elementor value.
+	 * @param string $fallback_unit Default unit when not provided.
+	 *
+	 * @return string
+	 */
+	private static function resolve_dimension( $value, string $fallback_unit ): string {
+		if ( is_array( $value ) ) {
+			$size = $value['size'] ?? $value['value'] ?? '';
+			$unit = $value['unit'] ?? $fallback_unit;
+			if ( '' === $unit ) {
+				$unit = $fallback_unit;
+			}
+			if ( '' !== $size ) {
+				return $size . $unit;
+			}
+			return '';
+		}
+
+		if ( null === $value || '' === $value ) {
+			return '';
+		}
+
+		$value = (string) $value;
+		if ( 'default' === strtolower( $value ) ) {
+			return '';
+		}
+		if ( preg_match( '/[a-z%]+$/i', $value ) ) {
+			return $value;
+		}
+
+		if ( '' === $fallback_unit ) {
+			$fallback_unit = 'px';
+		}
+
+		return $value . $fallback_unit;
+	}
+
+	/**
+	 * Extract background color from settings.
+	 *
+	 * @param array $settings Elementor settings.
+	 *
+	 * @return string
+	 */
+	private static function get_background_color( array $settings ): string {
+		$keys = array( '_background_color', 'background_color' );
+		foreach ( $keys as $key ) {
+			if ( isset( $settings[ $key ] ) && '' !== (string) $settings[ $key ] ) {
+				return (string) $settings[ $key ];
+			}
+		}
+
+		return '';
 	}
 }

--- a/src/admin/layout/class-columns-widths.php
+++ b/src/admin/layout/class-columns-widths.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Normalize Elementor column widths to Gutenberg percentages.
+ *
+ * @package Progressus\Gutenberg
+ */
+
+namespace Progressus\Gutenberg\Admin\Layout;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalize Elementor widths for Gutenberg columns.
+ */
+class Columns_Widths {
+	/**
+	 * Normalize column widths to percentage strings that add up to ~100%.
+	 *
+	 * @param array $children Column children.
+	 *
+	 * @return array<string>
+	 */
+	public static function normalize( array $children ): array {
+		$count = count( $children );
+		if ( 0 === $count ) {
+			return array();
+		}
+
+		$positive_indices = array();
+		$zero_indices     = array();
+
+		foreach ( $children as $index => $child ) {
+			$hint = self::width_hint( $child );
+			if ( $hint > 0 ) {
+				$positive_indices[ $index ] = $hint;
+			} else {
+				$zero_indices[] = $index;
+			}
+		}
+
+		if ( empty( $positive_indices ) ) {
+			$equal = 100 / $count;
+			return self::distribute_evenly( $count, $equal );
+		}
+
+		$positive_total = array_sum( $positive_indices );
+		if ( $positive_total <= 0 ) {
+			$equal = 100 / $count;
+			return self::distribute_evenly( $count, $equal );
+		}
+
+		$percentages         = array_fill( 0, $count, 0.0 );
+		$last_positive_index = array_key_last( $positive_indices );
+
+		foreach ( $positive_indices as $index => $hint ) {
+			$value = round( ( $hint / $positive_total ) * 100, 2 );
+			$percentages[ $index ] = max( $value, 0.0 );
+		}
+
+		$total_assigned = array_sum( $percentages );
+		if ( $total_assigned > 100 ) {
+			$excess = $total_assigned - 100;
+			if ( null !== $last_positive_index ) {
+				$percentages[ $last_positive_index ] = max( $percentages[ $last_positive_index ] - $excess, 0.0 );
+			}
+			$remaining = 0.0;
+		} else {
+			$remaining = 100.0 - $total_assigned;
+		}
+
+		if ( ! empty( $zero_indices ) ) {
+			$zero_count = count( $zero_indices );
+			foreach ( $zero_indices as $i => $zero_index ) {
+				if ( $i === $zero_count - 1 ) {
+					$percentages[ $zero_index ] = max( $remaining, 0.0 );
+					break;
+				}
+				$share                        = round( $remaining / ( $zero_count - $i ), 2 );
+				$percentages[ $zero_index ]   = max( $share, 0.0 );
+				$remaining                   -= $percentages[ $zero_index ];
+			}
+		} elseif ( null !== $last_positive_index ) {
+			$percentages[ $last_positive_index ] += max( $remaining, 0.0 );
+		}
+
+		$result = array();
+		foreach ( $percentages as $value ) {
+			$result[] = self::format_percentage( $value );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Extract width hint from a child element.
+	 *
+	 * @param array $child Elementor child element.
+	 *
+	 * @return float
+	 */
+	public static function width_hint( array $child ): float {
+		$settings = $child['settings'] ?? array();
+
+		if ( isset( $settings['_column_size'] ) ) {
+			return (float) $settings['_column_size'];
+		}
+
+		if ( isset( $settings['width'] ) ) {
+			$width_setting = $settings['width'];
+			if ( is_array( $width_setting ) ) {
+				if ( isset( $width_setting['size'] ) && '' !== $width_setting['size'] ) {
+					return (float) $width_setting['size'];
+				}
+			} elseif ( '' !== $width_setting ) {
+				return (float) $width_setting;
+			}
+		}
+
+		if ( isset( $child['width'] ) && '' !== $child['width'] ) {
+			return (float) $child['width'];
+		}
+
+		return 0.0;
+	}
+
+	/**
+	 * Create evenly distributed widths.
+	 *
+	 * @param int   $count Number of columns.
+	 * @param float $base  Base percentage.
+	 *
+	 * @return array<string>
+	 */
+	private static function distribute_evenly( int $count, float $base ): array {
+		$widths    = array();
+		$remaining = 100.0;
+
+		for ( $index = 0; $index < $count; $index++ ) {
+			if ( $index === $count - 1 ) {
+				$widths[] = self::format_percentage( $remaining );
+				break;
+			}
+
+			$value      = round( $base, 2 );
+			$remaining -= $value;
+			$widths[]   = self::format_percentage( $value );
+		}
+
+		return $widths;
+	}
+
+	/**
+	 * Format a float as percentage string.
+	 *
+	 * @param float $value Float value.
+	 *
+	 * @return string
+	 */
+	private static function format_percentage( float $value ): string {
+		if ( $value < 0 ) {
+			$value = 0.0;
+		}
+
+		return rtrim( rtrim( number_format( $value, 2, '.', '' ), '0' ), '.' ) . '%';
+	}
+}

--- a/src/admin/layout/class-container-classifier.php
+++ b/src/admin/layout/class-container-classifier.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Decide which Gutenberg layout to use when rendering Elementor containers.
+ *
+ * @package Progressus\Gutenberg
+ */
+
+namespace Progressus\Gutenberg\Admin\Layout;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Determine which layout a container should use.
+ */
+class Container_Classifier {
+	/**
+	 * Determine if a container should render as a grid.
+	 *
+	 * @param array $element Elementor container element.
+	 *
+	 * @return bool
+	 */
+	public static function is_grid( array $element ): bool {
+		$settings = $element['settings'] ?? array();
+		$child_count = isset( $element['elements'] ) && is_array( $element['elements'] ) ? count( $element['elements'] ) : 0;
+
+		if ( isset( $settings['layout'] ) && 'grid' === $settings['layout'] ) {
+			return true;
+		}
+
+		if ( isset( $settings['display'] ) && 'grid' === $settings['display'] ) {
+			return true;
+		}
+
+		if ( isset( $settings['grid_columns'] ) || isset( $settings['grid_template_columns'] ) || isset( $settings['grid_auto_flow'] ) ) {
+			return true;
+		}
+
+		if ( isset( $settings['grid_row_gap'] ) || isset( $settings['gap_rows'] ) ) {
+			return true;
+		}
+
+		if ( $child_count > 4 ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determine whether we should render a container as columns.
+	 *
+	 * @param array $element  Elementor container element.
+	 * @param array $children Children elements.
+	 *
+	 * @return bool
+	 */
+	public static function should_render_columns( array $element, array $children ): bool {
+		$child_count = count( $children );
+		if ( $child_count < 2 || $child_count > 4 ) {
+			return false;
+		}
+
+		if ( self::is_grid( $element ) ) {
+			return false;
+		}
+
+		$settings = $element['settings'] ?? array();
+		$direction = self::get_flex_direction( $settings );
+		if ( 'column' === $direction || 'column-reverse' === $direction ) {
+			return false;
+		}
+
+		$wrap = $settings['flex_wrap'] ?? $settings['flex_wrap_mobile'] ?? '';
+		if ( in_array( $wrap, array( 'wrap', 'wrap-reverse' ), true ) && $child_count > 3 ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Infer a grid column count from Elementor settings.
+	 *
+	 * @param array $element     Elementor container element.
+	 * @param int   $child_count Number of children.
+	 *
+	 * @return int
+	 */
+	public static function get_grid_column_count( array $element, int $child_count ): int {
+		$settings = $element['settings'] ?? array();
+		$possible_keys = array( 'grid_columns', 'columns', 'grid_columns_number', 'grid_template_columns' );
+
+		foreach ( $possible_keys as $key ) {
+			if ( empty( $settings[ $key ] ) ) {
+				continue;
+			}
+
+			$value = $settings[ $key ];
+			if ( is_array( $value ) ) {
+				$value = $value['size'] ?? reset( $value );
+			}
+
+			$value = (int) $value;
+			if ( $value > 0 ) {
+				return min( max( 1, $value ), max( 1, $child_count ) );
+			}
+		}
+
+		if ( $child_count >= 4 ) {
+			return 4;
+		}
+
+		if ( $child_count >= 3 ) {
+			return 3;
+		}
+
+		if ( $child_count > 0 ) {
+			return $child_count;
+		}
+
+		return 1;
+	}
+
+	/**
+	 * Get the flex direction configured for a container.
+	 *
+	 * @param array $settings Elementor settings array.
+	 *
+	 * @return string
+	 */
+	public static function get_flex_direction( array $settings ): string {
+		$direction = $settings['flex_direction'] ?? $settings['direction'] ?? '';
+
+		$valid = array( 'row', 'row-reverse', 'column', 'column-reverse' );
+		if ( in_array( $direction, $valid, true ) ) {
+			return $direction;
+		}
+
+		return 'row';
+	}
+}


### PR DESCRIPTION
## Summary
- add a Block_Builder helper that serializes Gutenberg structural blocks with wrapper markup and inline styles
- extend Style_Parser and introduce Container_Classifier/Columns_Widths helpers to drive Elementor container layout decisions
- refactor Admin_Settings to build columns-first, grid, and group markup through the new helpers

## Testing
- php -l src/admin/class-admin-settings.php
- php -l src/admin/helper/class-block-builder.php
- php -l src/admin/helper/class-style-parser.php
- php -l src/admin/layout/class-container-classifier.php
- php -l src/admin/layout/class-columns-widths.php


------
https://chatgpt.com/codex/tasks/task_e_68db186af6f0832f9b5d38d76b0d95bc