### PR TITLE
Add grid container support and harden widget styles

### DIFF
--- a/src/admin/helper/class-style-parser.php
+++ b/src/admin/helper/class-style-parser.php
@@ -19,49 +19,76 @@ class Style_Parser {
 	 * @param array $settings The Elementor settings array.
 	 * @return array Array containing 'attributes' and 'style' keys.
 	 */
-	public static function parse_typography( array $settings ): array {
-		$attrs = array();
-		$style = '';
+        public static function parse_typography( array $settings ): array {
+                $attrs       = array();
+                $style_rules = array();
 
-		$typography_fields = array(
-			'typography_font_family'     => array( 'attr' => 'fontFamily', 'style' => 'font-family' ),
-			'typography_text_transform'  => array( 'attr' => 'textTransform', 'style' => 'text-transform' ),
-			'typography_font_size'       => array( 'attr' => 'fontSize', 'style' => 'font-size', 'is_array' => true ),
-			'typography_font_weight'     => array( 'attr' => 'fontWeight', 'style' => 'font-weight' ),
-			'typography_line_height'     => array( 'attr' => 'lineHeight', 'style' => 'line-height', 'is_array' => true ),
-			'typography_font_style'      => array( 'attr' => 'fontStyle', 'style' => 'font-style' ),
-			'typography_text_decoration' => array( 'attr' => 'textDecoration', 'style' => 'text-decoration' ),
-			'typography_letter_spacing'  => array( 'attr' => 'letterSpacing', 'style' => 'letter-spacing', 'is_array' => true ),
-			'typography_word_spacing'    => array( 'attr' => 'wordSpacing', 'style' => 'word-spacing', 'is_array' => true ),
-		);
+                $typography_fields = array(
+                        'typography_font_family'     => array( 'attr' => 'fontFamily', 'style' => 'font-family' ),
+                        'typography_text_transform'  => array( 'attr' => 'textTransform', 'style' => 'text-transform' ),
+                        'typography_font_size'       => array( 'attr' => 'fontSize', 'style' => 'font-size', 'is_array' => true, 'unit' => 'px' ),
+                        'typography_font_weight'     => array( 'attr' => 'fontWeight', 'style' => 'font-weight' ),
+                        'typography_line_height'     => array( 'attr' => 'lineHeight', 'style' => 'line-height', 'is_array' => true, 'unit' => '' ),
+                        'typography_font_style'      => array( 'attr' => 'fontStyle', 'style' => 'font-style' ),
+                        'typography_text_decoration' => array( 'attr' => 'textDecoration', 'style' => 'text-decoration' ),
+                        'typography_letter_spacing'  => array( 'attr' => 'letterSpacing', 'style' => 'letter-spacing', 'is_array' => true, 'unit' => 'px' ),
+                        'typography_word_spacing'    => array( 'attr' => 'wordSpacing', 'style' => 'word-spacing', 'is_array' => true, 'unit' => 'px' ),
+                );
 
-		foreach ( $typography_fields as $key => $field ) {
-			if ( ! isset( $settings[ $key ] ) ) {
-				continue;
-			}
+                foreach ( $typography_fields as $key => $field ) {
+                        if ( ! isset( $settings[ $key ] ) ) {
+                                continue;
+                        }
 
-			if ( ! empty( $field['is_array'] ) ) {
-				$size = $settings[ $key ]['size'] ?? '';
-				$unit = $settings[ $key ]['unit'] ?? ( 'typography_line_height' === $key ? '' : 'px' );
-				if ( '' !== $size && is_numeric( $size ) ) {
-					$value = $size . $unit;
-					$attrs[ $field['attr'] ] = $value;
-					$style .= sprintf( '%s:%s;', $field['style'], esc_attr( $value ) );
-				}
-			} else {
-				$value = $settings[ $key ];
-				if ( '' !== $value ) {
-					$attrs[ $field['attr'] ] = $value;
-					$style .= sprintf( '%s:%s;', $field['style'], esc_attr( $value ) );
-				}
-			}
-		}
+                        if ( ! empty( $field['is_array'] ) ) {
+                                $value_data = $settings[ $key ];
+                                if ( ! is_array( $value_data ) ) {
+                                        continue;
+                                }
 
-		return array(
-			'attributes' => $attrs,
-			'style'      => $style,
-		);
-	}
+                                $size = $value_data['size'] ?? null;
+                                if ( null === $size || '' === $size ) {
+                                        continue;
+                                }
+
+                                $unit = $value_data['unit'] ?? ( $field['unit'] ?? 'px' );
+                                if ( ! is_string( $unit ) ) {
+                                        $unit = (string) $unit;
+                                }
+
+                                $size = is_numeric( $size ) ? (string) $size : trim( (string) $size );
+                                if ( '' === $size ) {
+                                        continue;
+                                }
+
+                                if ( '' === $unit && isset( $field['unit'] ) && is_numeric( $size ) ) {
+                                        $unit = $field['unit'];
+                                }
+
+                                $value = $size . $unit;
+                                $attrs[ $field['attr'] ] = $value;
+                                $style_rules[]           = sprintf( '%s:%s;', $field['style'], esc_attr( $value ) );
+                        } else {
+                                $value = $settings[ $key ];
+                                if ( '' === $value || null === $value ) {
+                                        continue;
+                                }
+
+                                $value = is_scalar( $value ) ? (string) $value : '';
+                                if ( '' === $value ) {
+                                        continue;
+                                }
+
+                                $attrs[ $field['attr'] ] = $value;
+                                $style_rules[]           = sprintf( '%s:%s;', $field['style'], esc_attr( $value ) );
+                        }
+                }
+
+                return array(
+                        'attributes' => $attrs,
+                        'style'      => implode( '', $style_rules ),
+                );
+        }
 
 	/**
 	 * Parse spacing settings from Elementor settings.
@@ -69,32 +96,53 @@ class Style_Parser {
 	 * @param array $settings The Elementor settings array.
 	 * @return array Array containing 'attributes' and 'style' keys.
 	 */
-	public static function parse_spacing( array $settings ): array {
-		$attrs = array();
-		$style = '';
+        public static function parse_spacing( array $settings ): array {
+                $attrs       = array();
+                $style_rules = array();
 
-		foreach ( array( 'padding', 'margin' ) as $spacing ) {
-			$key = '_' . $spacing;
-			if ( ! isset( $settings[ $key ] ) || ! is_array( $settings[ $key ] ) ) {
-				continue;
-			}
+                foreach ( array( 'padding', 'margin' ) as $spacing ) {
+                        $value_map = null;
+                        foreach ( array( $spacing, '_' . $spacing ) as $key ) {
+                                if ( isset( $settings[ $key ] ) && is_array( $settings[ $key ] ) ) {
+                                        $value_map = $settings[ $key ];
+                                        break;
+                                }
+                        }
 
-			$unit = $settings[ $key ]['unit'] ?? 'px';
+                        if ( empty( $value_map ) || ! is_array( $value_map ) ) {
+                                continue;
+                        }
 
-			foreach ( array( 'top', 'bottom', 'left', 'right' ) as $side ) {
-				if ( isset( $settings[ $key ][ $side ] ) && '' !== $settings[ $key ][ $side ] ) {
-					$value = $settings[ $key ][ $side ] . $unit;
-					$attrs[ $spacing ][ $side ] = $value;
-					$style .= sprintf( '%s-%s:%s;', $spacing, $side, esc_attr( $value ) );
-				}
-			}
-		}
+                        $unit = $value_map['unit'] ?? 'px';
+                        if ( ! is_string( $unit ) ) {
+                                $unit = 'px';
+                        }
 
-		return array(
-			'attributes' => $attrs ? : array(),
-			'style'      => $style,
-		);
-	}
+                        foreach ( array( 'top', 'bottom', 'left', 'right' ) as $side ) {
+                                if ( ! isset( $value_map[ $side ] ) ) {
+                                        continue;
+                                }
+
+                                $raw_value = $value_map[ $side ];
+                                if ( '' === $raw_value || null === $raw_value ) {
+                                        continue;
+                                }
+
+                                $value = is_numeric( $raw_value ) ? (string) $raw_value . $unit : trim( (string) $raw_value );
+                                if ( '' === $value ) {
+                                        continue;
+                                }
+
+                                $attrs[ $spacing ][ $side ] = $value;
+                                $style_rules[]              = sprintf( '%s-%s:%s;', $spacing, $side, esc_attr( $value ) );
+                        }
+                }
+
+                return array(
+                        'attributes' => $attrs,
+                        'style'      => implode( '', $style_rules ),
+                );
+        }
 
 	/**
 	 * Parse border settings from Elementor settings.
@@ -102,63 +150,121 @@ class Style_Parser {
 	 * @param array $settings The Elementor settings array.
 	 * @return array Array containing 'attributes' and 'style' keys.
 	 */
-	public static function parse_border( array $settings ): array {
-		$attrs = array();
-		$style = '';
+        public static function parse_border( array $settings ): array {
+                $attrs       = array();
+                $style_rules = array();
 
-		// Map Elementor sides to Gutenberg sides.
-		$radius_map = array(
-			'top'    => array( 'topLeft', 'top-left' ),
-			'right'  => array( 'topRight', 'top-right' ),
-			'bottom' => array( 'bottomRight', 'bottom-right' ),
-			'left'   => array( 'bottomLeft', 'bottom-left' ),
-		);
+                $radius_map = array(
+                        'top'    => array( 'topLeft', 'top-left' ),
+                        'right'  => array( 'topRight', 'top-right' ),
+                        'bottom' => array( 'bottomRight', 'bottom-right' ),
+                        'left'   => array( 'bottomLeft', 'bottom-left' ),
+                );
 
-		// Border radius.
-		if ( isset( $settings['_border_radius'] ) && is_array( $settings['_border_radius'] ) ) {
-			$unit = $settings['_border_radius']['unit'] ?? 'px';
-			foreach ( $radius_map as $el_side => $gb_side ) {
-				if ( isset( $settings['_border_radius'][ $el_side ] ) && $settings['_border_radius'][ $el_side ] !== '' ) {
-					$value = $settings['_border_radius'][ $el_side ] . $unit;
-					$attrs['radius'][ $gb_side[0] ] = $value;
-					$style .= sprintf( 'border-%s-radius:%s;', 
-						$gb_side[1],
-						esc_attr( $value )
-					);
-				}
-			}
-		}
+                if ( isset( $settings['_border_radius'] ) && is_array( $settings['_border_radius'] ) ) {
+                        $unit = $settings['_border_radius']['unit'] ?? 'px';
+                        if ( ! is_string( $unit ) ) {
+                                $unit = 'px';
+                        }
 
-		// Border width + color per side.
-		if ( isset( $settings['_border_width'] ) && is_array( $settings['_border_width'] ) ) {
-			$unit = $settings['_border_width']['unit'] ?? 'px';
-			$color = ! empty( $settings['border_color'] ) ? strtolower( $settings['border_color'] ) : '';
+                        foreach ( $radius_map as $el_side => $gb_side ) {
+                                if ( ! isset( $settings['_border_radius'][ $el_side ] ) ) {
+                                        continue;
+                                }
 
-			foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
-				if ( isset( $settings['_border_width'][ $side ] ) && $settings['_border_width'][ $side ] !== '' ) {
-					$width = $settings['_border_width'][ $side ] . $unit;
-					$attrs[ $side ]['width'] = $width;
-					$style .= sprintf( 'border-%s-width:%s;', $side, esc_attr( $width ) );
+                                $raw_value = $settings['_border_radius'][ $el_side ];
+                                if ( '' === $raw_value || null === $raw_value ) {
+                                        continue;
+                                }
 
-					if ( $color ) {
-						$attrs[ $side ]['color'] = $color;
-						$style .= sprintf( 'border-%s-color:%s;', $side, esc_attr( $color ) );
-					}
-				}
-			}
-		}
+                                $value = is_numeric( $raw_value ) ? (string) $raw_value . $unit : trim( (string) $raw_value );
+                                if ( '' === $value ) {
+                                        continue;
+                                }
 
-		// Border style (solid, dashed, etc.)
-		if ( ! empty( $settings['_border_border'] ) ) {
-			$attrs['style'] = $settings['_border_border'];
-			$style .= 'border-style:' . esc_attr( $settings['_border_border'] ) . ';';
-		}
+                                $attrs['radius'][ $gb_side[0] ] = $value;
+                                $style_rules[]                  = sprintf( 'border-%s-radius:%s;', $gb_side[1], esc_attr( $value ) );
+                        }
+                }
 
-		return array(
-			'attributes' => $attrs ? : array(),
-			'style'      => $style,
-		);
-	}
+                if ( isset( $settings['_border_width'] ) && is_array( $settings['_border_width'] ) ) {
+                        $unit  = $settings['_border_width']['unit'] ?? 'px';
+                        $color = isset( $settings['border_color'] ) ? strtolower( (string) $settings['border_color'] ) : '';
+
+                        if ( ! is_string( $unit ) ) {
+                                $unit = 'px';
+                        }
+
+                        foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
+                                if ( ! isset( $settings['_border_width'][ $side ] ) ) {
+                                        continue;
+                                }
+
+                                $raw_width = $settings['_border_width'][ $side ];
+                                if ( '' === $raw_width || null === $raw_width ) {
+                                        continue;
+                                }
+
+                                $width = is_numeric( $raw_width ) ? (string) $raw_width . $unit : trim( (string) $raw_width );
+                                if ( '' === $width ) {
+                                        continue;
+                                }
+
+                                $attrs[ $side ]['width'] = $width;
+                                $style_rules[]           = sprintf( 'border-%s-width:%s;', $side, esc_attr( $width ) );
+
+                                if ( '' !== $color ) {
+                                        $attrs[ $side ]['color'] = $color;
+                                        $style_rules[]           = sprintf( 'border-%s-color:%s;', $side, esc_attr( $color ) );
+                                }
+                        }
+                }
+
+                if ( ! empty( $settings['_border_border'] ) && is_string( $settings['_border_border'] ) ) {
+                        $attrs['style'] = $settings['_border_border'];
+                        $style_rules[]  = 'border-style:' . esc_attr( $settings['_border_border'] ) . ';';
+                }
+
+                if ( empty( $attrs ) && empty( $style_rules ) ) {
+                        return array();
+                }
+
+                return array(
+                        'attributes' => $attrs,
+                        'style'      => implode( '', $style_rules ),
+                );
+        }
+
+        /**
+         * Parse container-level styles from Elementor settings.
+         *
+         * @param array $settings Elementor settings array.
+         *
+         * @return array
+         */
+        public static function parse_container_styles( array $settings ): array {
+                $attrs       = array();
+                $style_rules = array();
+
+                $background = $settings['background_color'] ?? $settings['_background_color'] ?? '';
+                if ( is_string( $background ) ) {
+                        $background = trim( strtolower( $background ) );
+                }
+
+                if ( ! empty( $background ) ) {
+                        $attrs['color']['background'] = $background;
+                        $style_rules[]                = 'background-color:' . esc_attr( $background ) . ';';
+                }
+
+                if ( empty( $attrs ) && empty( $style_rules ) ) {
+                        return array();
+                }
+
+                return array(
+                        'attributes' => $attrs,
+                        'style'      => implode( '', $style_rules ),
+                );
+        }
 
 
 	/**

--- a/src/admin/layout/class-container-classifier.php
+++ b/src/admin/layout/class-container-classifier.php
@@ -20,21 +20,29 @@ class Container_Classifier {
 	 *
 	 * @return bool
 	 */
-	public static function is_grid( array $element ): bool {
-		$settings = $element['settings'] ?? array();
-		$child_count = isset( $element['elements'] ) && is_array( $element['elements'] ) ? count( $element['elements'] ) : 0;
+        public static function is_grid( array $element ): bool {
+                $settings    = $element['settings'] ?? array();
+                $child_count = isset( $element['elements'] ) && is_array( $element['elements'] ) ? count( $element['elements'] ) : 0;
 
-		if ( isset( $settings['layout'] ) && 'grid' === $settings['layout'] ) {
-			return true;
-		}
+                if ( isset( $settings['container_type'] ) && 'grid' === $settings['container_type'] ) {
+                        return true; // Elementor “simple” export
+                }
+
+                if ( isset( $settings['layout'] ) && 'grid' === $settings['layout'] ) {
+                        return true;
+                }
 
 		if ( isset( $settings['display'] ) && 'grid' === $settings['display'] ) {
 			return true;
 		}
 
-		if ( isset( $settings['grid_columns'] ) || isset( $settings['grid_template_columns'] ) || isset( $settings['grid_auto_flow'] ) ) {
-			return true;
-		}
+                if ( isset( $settings['grid_columns'] ) || isset( $settings['grid_template_columns'] ) || isset( $settings['grid_auto_flow'] ) ) {
+                        return true;
+                }
+
+                if ( isset( $settings['grid_columns_grid'] ) || isset( $settings['grid_rows_grid'] ) ) {
+                        return true;
+                }
 
 		if ( isset( $settings['grid_row_gap'] ) || isset( $settings['gap_rows'] ) ) {
 			return true;
@@ -88,8 +96,16 @@ class Container_Classifier {
 	 * @return int
 	 */
 	public static function get_grid_column_count( array $element, int $child_count ): int {
-		$settings = $element['settings'] ?? array();
-		$possible_keys = array( 'grid_columns', 'columns', 'grid_columns_number', 'grid_template_columns' );
+                $settings = $element['settings'] ?? array();
+
+                if ( ! empty( $settings['grid_columns_grid'] ) && is_array( $settings['grid_columns_grid'] ) ) {
+                        $val = (int) ( $settings['grid_columns_grid']['size'] ?? 0 );
+                        if ( $val > 0 ) {
+                                return min( max( 1, $val ), max( 1, $child_count ) );
+                        }
+                }
+
+                $possible_keys = array( 'grid_columns', 'columns', 'grid_columns_number', 'grid_template_columns' );
 
 		foreach ( $possible_keys as $key ) {
 			if ( empty( $settings[ $key ] ) ) {

--- a/src/admin/widget/class-button-widget-handler.php
+++ b/src/admin/widget/class-button-widget-handler.php
@@ -23,91 +23,108 @@ class Button_Widget_Handler implements Widget_Handler_Interface {
 	 * @param array $element The Elementor element data.
 	 * @return string The Gutenberg block content.
 	 */
-	public function handle( array $element ): string {
-		$settings     = $element['settings'] ?? array();
-		$text         = $settings['text'] ?? '';
-		$url          = $settings['link']['url'] ?? '';
-		$custom_class = $settings['_css_classes'] ?? '';
-		$custom_id    = $settings['_element_id'] ?? '';
-		$custom_css   = $settings['custom_css'] ?? '';
+        public function handle( array $element ): string {
+                $settings     = $element['settings'] ?? array();
+                $text         = $settings['text'] ?? '';
+                $url          = $settings['link']['url'] ?? '';
+                $custom_class = trim( (string) ( $settings['_css_classes'] ?? '' ) );
+                $custom_id    = $settings['_element_id'] ?? '';
+                $custom_css   = $settings['custom_css'] ?? '';
 
-		$class = '';
-		if ( ! empty( $custom_class ) ) {
-			$class .= ' ' . esc_attr( $custom_class );
-		}
+                $class_parts = array();
+                if ( '' !== $custom_class ) {
+                        $class_parts = array_merge( $class_parts, preg_split( '/\s+/', $custom_class ) ?: array() );
+                }
 
-		$attrs_array = array();
-		$inline_style = '';
+                $attrs_array = array();
+                $inline_style = '';
 
-		if ( $url ) {
-			$attrs_array['url'] = esc_url( $url );
-		}
+                if ( $url ) {
+                        $attrs_array['url'] = esc_url( $url );
+                }
 
-		if ( ! empty( $settings['button_text_color'] ) ) {
-			$txt = strtolower( $settings['button_text_color'] );
-			$class .= ' has-text-color has-link-color';
-			if ( $this->is_preset_color_slug( $txt ) ) {
-				$attrs_array['textColor'] = $txt;
-				$class .= ' has-text-color has-link-color';
-				$attrs_array['style']['elements']['link']['color']['text'] = 'var:preset|color|' . $txt;
-			} else {
-				$attrs_array['style']['color']['text'] = $txt;
-				$attrs_array['style']['elements']['link']['color']['text'] = $txt;
-				$inline_style .= 'color:' . $txt . ';';
-			}
+                $text_color = isset( $settings['button_text_color'] ) ? strtolower( (string) $settings['button_text_color'] ) : '';
+                if ( '' !== $text_color ) {
+                        $class_parts[] = 'has-text-color';
+                        $class_parts[] = 'has-link-color';
+                        if ( $this->is_preset_color_slug( $text_color ) ) {
+                                $attrs_array['textColor'] = $text_color;
+                                $attrs_array['style']['elements']['link']['color']['text'] = 'var:preset|color|' . $text_color;
+                        } else {
+                                $attrs_array['style']['color']['text']                     = $text_color;
+                                $attrs_array['style']['elements']['link']['color']['text'] = $text_color;
+                                $inline_style                                               .= 'color:' . esc_attr( $text_color ) . ';';
+                        }
+                }
 
-		}
+                $background_color = isset( $settings['background_color'] ) ? strtolower( (string) $settings['background_color'] ) : '';
+                if ( '' !== $background_color ) {
+                        $class_parts[] = 'has-background';
+                        if ( $this->is_preset_color_slug( $background_color ) ) {
+                                $attrs_array['backgroundColor'] = $background_color;
+                        } else {
+                                $attrs_array['style']['color']['background'] = $background_color;
+                                $inline_style                                .= 'background-color:' . esc_attr( $background_color ) . ';';
+                        }
+                }
 
-		if ( ! empty( $settings['background_color'] ) ) {
-			$bg = strtolower( $settings['background_color'] );
-			$class .= ' has-background';
-			if ( $this->is_preset_color_slug( $bg ) ) {
-				$attrs_array['backgroundColor'] = $bg;
-			} else {
-				$attrs_array['style']['color']['background'] = $bg;
-				$inline_style .= 'background-color:' . $bg . ';';
-			}
-		}
+                $typography    = Style_Parser::parse_typography( $settings );
+                $typo_attrs    = is_array( $typography['attributes'] ?? null ) ? $typography['attributes'] : array();
+                $typo_css      = is_string( $typography['style'] ?? null ) ? $typography['style'] : '';
+                $spacing       = Style_Parser::parse_spacing( $settings );
+                $spacing_attrs = is_array( $spacing['attributes'] ?? null ) ? $spacing['attributes'] : array();
+                $spacing_css   = is_string( $spacing['style'] ?? null ) ? $spacing['style'] : '';
+                $border        = Style_Parser::parse_border( $settings );
+                $border_attrs  = is_array( $border['attributes'] ?? null ) ? $border['attributes'] : array();
+                $border_css    = is_string( $border['style'] ?? null ) ? $border['style'] : '';
 
-		// Typography, spacing, border.
-		$typography = Style_Parser::parse_typography( $settings );
-		$spacing    = Style_Parser::parse_spacing( $settings );
-		$border     = Style_Parser::parse_border( $settings );
+                if ( ! empty( $typo_attrs ) ) {
+                        $attrs_array['style']['typography'] = $typo_attrs;
+                }
 
-		if ( ! empty( $typography['attributes'] ) ) {
-			$attrs_array['style']['typography'] = $typography['attributes'];
-		}
-		if ( ! empty( $spacing['attributes'] ) ) {
-			$attrs_array['style']['spacing'] = $spacing['attributes'];
-		}
-		if ( ! empty( $border['attributes'] ) ) {
-			$attrs_array['style']['border'] = $border['attributes'];
-		}
+                if ( ! empty( $spacing_attrs ) ) {
+                        $attrs_array['style']['spacing'] = $spacing_attrs;
+                }
 
-		// Inline style fallback (optional, safe for editor).
-		$inline_style .= $typography['style'] . $spacing['style'] . $border['style'];
+                if ( ! empty( $border_attrs ) ) {
+                        $attrs_array['style']['border'] = $border_attrs;
+                }
 
-		// Encode attributes.
-		$attrs = wp_json_encode( $attrs_array );
+                if ( isset( $attrs_array['style'] ) ) {
+                        foreach ( $attrs_array['style'] as $key => $value ) {
+                                if ( empty( $value ) ) {
+                                        unset( $attrs_array['style'][ $key ] );
+                                }
+                        }
+                        if ( empty( $attrs_array['style'] ) ) {
+                                unset( $attrs_array['style'] );
+                        }
+                }
 
-		// Build block content.
-		$block_content = sprintf(
-			'<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button %1s --><div class="wp-block-button"><a id="%2s" class="wp-block-button__link %3s wp-element-button"%4s%5s>%6s</a></div><!-- /wp:button --></div><!-- /wp:buttons -->' . "\n",
-			$attrs,
-			esc_attr( $custom_id ),
-			esc_attr( $class ),
-			$inline_style ? ' style="' . esc_attr( $inline_style ) . '"' : '',
-			$url ? ' href="' . esc_url( $url ) . '"' : '',
-			esc_html( $text )
-		);
+                $inline_style .= $typo_css . $spacing_css . $border_css;
 
-		// Save custom CSS if any.
-		if ( ! empty( $custom_css ) ) {
-			Style_Parser::save_custom_css( $custom_css );
-		}
+                $class_parts = array_filter( array_map( 'sanitize_html_class', $class_parts ) );
+                $class_name  = trim( implode( ' ', $class_parts ) );
+                $class_suffix = '' !== $class_name ? ' ' . $class_name : '';
 
-		return $block_content;
-	}
+                $attrs = ! empty( $attrs_array ) ? wp_json_encode( $attrs_array ) : '{}';
+
+                $block_content = sprintf(
+                        '<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button %1$s --><div class="wp-block-button"><a id="%2$s" class="wp-block-button__link%3$s wp-element-button"%4$s%5$s>%6$s</a></div><!-- /wp:button --></div><!-- /wp:buttons -->' . "\n",
+                        $attrs,
+                        esc_attr( $custom_id ),
+                        esc_attr( $class_suffix ),
+                        $inline_style ? ' style="' . esc_attr( $inline_style ) . '"' : '',
+                        $url ? ' href="' . esc_url( $url ) . '"' : '',
+                        esc_html( $text )
+                );
+
+                if ( ! empty( $custom_css ) ) {
+                        Style_Parser::save_custom_css( $custom_css );
+                }
+
+                return $block_content;
+        }
 
 	/**
 	 * Check if a given color value is a Gutenberg preset slug.

--- a/src/admin/widget/class-heading-widget-handler.php
+++ b/src/admin/widget/class-heading-widget-handler.php
@@ -23,85 +23,111 @@ class Heading_Widget_Handler implements Widget_Handler_Interface {
 	 * @param array $element The Elementor element data.
 	 * @return string The Gutenberg block content.
 	 */
-	public function handle( array $element ): string {
-		$settings      = $element['settings'] ?? array();
-		$title         = $settings['title'] ?? '';
-		$level         = str_split( $settings['header_size'] )[1] ?? 2;
-		$text_color    = ! empty( $settings['title_color'] ) ? strtolower( $settings['title_color'] ) : '';
-		$custom_class  = $settings['_css_classes'] ?? '';
-		$unique_class  = 'heading-' . uniqid();
-		$custom_id     = $settings['_element_id'] ?? '';
-		$custom_css    = $settings['custom_css'] ?? '';
-		$custom_class .= ' ' . $unique_class;
+        public function handle( array $element ): string {
+                $settings     = $element['settings'] ?? array();
+                $title        = $settings['title'] ?? '';
+                $text_color   = isset( $settings['title_color'] ) ? strtolower( (string) $settings['title_color'] ) : '';
+                $custom_class = trim( (string) ( $settings['_css_classes'] ?? '' ) );
+                $unique_class = 'heading-' . uniqid();
+                $custom_id    = $settings['_element_id'] ?? '';
+                $custom_css   = $settings['custom_css'] ?? '';
 
-		$class = 'wp-block-heading';
+                $header_size = isset( $settings['header_size'] ) ? strtolower( (string) $settings['header_size'] ) : 'h2';
+                $level       = 2;
+                if ( preg_match( '/h([1-6])/', $header_size, $matches ) ) {
+                        $level = (int) $matches[1];
+                }
 
-		// Handle text transform.
-		if ( ! empty( $settings['typography_text_transform'] ) ) {
-			$class .= 'has-text-transform-' . esc_attr( $settings['typography_text_transform'] );
-		}
-		if ( ! empty( $custom_class ) ) {
-			$class .= ' ' . esc_attr( $custom_class );
-		}
+                $class_parts = array( 'wp-block-heading', $unique_class );
+                if ( '' !== $custom_class ) {
+                        $class_parts = array_merge( $class_parts, preg_split( '/\s+/', $custom_class ) ?: array() );
+                }
 
-		$typography  = Style_Parser::parse_typography( $settings );
-		$border      = Style_Parser::parse_border( $settings );
-		$spacing	 = Style_Parser::parse_spacing( $settings );
+                if ( ! empty( $settings['typography_text_transform'] ) ) {
+                        $class_parts[] = 'has-text-transform-' . sanitize_html_class( $settings['typography_text_transform'] );
+                }
 
-		$attrs_array['level'] = (int) $level;
-		// Handle text + link color.
-		$inline_style = '';
-		if ( $this->is_preset_color_slug( $text_color ) ) {
-			// Preset slug.
-			$attrs_array['textColor'] = $text_color;
-			$attrs_array['style']['elements']['link']['color']['text'] = 'var:preset|color|' . $text_color;
-			$class .= ' has-text-color has-link-color';
-		} elseif ( ! empty( $text_color ) ) {
-			// Raw hex.
-			$attrs_array['style']['color']['text'] = $text_color;
-			$attrs_array['style']['elements']['link']['color']['text'] = $text_color;
-			$class .= ' has-text-color has-link-color';
+                $typography    = Style_Parser::parse_typography( $settings );
+                $typo_attrs    = is_array( $typography['attributes'] ?? null ) ? $typography['attributes'] : array();
+                $typo_css      = is_string( $typography['style'] ?? null ) ? $typography['style'] : '';
+                $border        = Style_Parser::parse_border( $settings );
+                $border_attrs  = is_array( $border['attributes'] ?? null ) ? $border['attributes'] : array();
+                $border_css    = is_string( $border['style'] ?? null ) ? $border['style'] : '';
+                $spacing       = Style_Parser::parse_spacing( $settings );
+                $spacing_attrs = is_array( $spacing['attributes'] ?? null ) ? $spacing['attributes'] : array();
+                $spacing_css   = is_string( $spacing['style'] ?? null ) ? $spacing['style'] : '';
 
-			// Add inline style for both text + link.
-			$inline_style .= 'color:' . esc_attr( $text_color ) . ';';
-		}
+                $attrs_array = array(
+                        'level' => $level,
+                );
 
-		$attrs_array['className'] = trim( $class );
+                $inline_style = '';
+                if ( $this->is_preset_color_slug( $text_color ) ) {
+                        $attrs_array['textColor']                                  = $text_color;
+                        $attrs_array['style']['elements']['link']['color']['text'] = 'var:preset|color|' . $text_color;
+                        $class_parts[]                                             = 'has-text-color';
+                        $class_parts[]                                             = 'has-link-color';
+                } elseif ( '' !== $text_color ) {
+                        $attrs_array['style']['color']['text']                     = $text_color;
+                        $attrs_array['style']['elements']['link']['color']['text'] = $text_color;
+                        $inline_style                                             .= 'color:' . esc_attr( $text_color ) . ';';
+                        $class_parts[]                                             = 'has-text-color';
+                        $class_parts[]                                             = 'has-link-color';
+                }
 
-		if ( ! empty( $typography['attributes'] ) ) {
-			$attrs_array['style']['typography'] = $typography['attributes'];
-		}
-		if ( ! empty( $spacing['attributes'] ) ) {
-			$attrs_array['style']['spacing'] = $spacing['attributes'];
-		}
-		if ( ! empty( $border['attributes'] ) ) {
-			$attrs_array['style']['border'] = $border['attributes'];
-		}
-		$inline_style .= $typography['style'] . $border['style'] . $spacing['style'];
-		// Encode block attributes.
-		$attrs = wp_json_encode( $attrs_array );
+                if ( ! empty( $typo_attrs ) ) {
+                        $attrs_array['style']['typography'] = $typo_attrs;
+                }
 
-		// Build block output.
-		$block_content = sprintf(
-			'<!-- wp:heading %s --><h%s id="%s" class="%s"%s>%s</h%s><!-- /wp:heading -->' . "\n",
-			$attrs,
-			esc_html( $level ),
-			esc_attr( $custom_id ),
-			esc_attr( $class ),
-			$inline_style ? ' style="' . esc_attr( $inline_style ) . '"' : '',
-			esc_html( $title ),
-			esc_html( $level )
-		);
+                if ( ! empty( $spacing_attrs ) ) {
+                        $attrs_array['style']['spacing'] = $spacing_attrs;
+                }
 
-		// Save custom CSS if any.
-		if ( ! empty( $custom_css ) ) {
-			Style_Parser::save_custom_css( $custom_css );
-		}
+                if ( ! empty( $border_attrs ) ) {
+                        $attrs_array['style']['border'] = $border_attrs;
+                }
 
-		return $block_content;
-	}
+                if ( isset( $attrs_array['style'] ) ) {
+                        foreach ( $attrs_array['style'] as $key => $value ) {
+                                if ( empty( $value ) ) {
+                                        unset( $attrs_array['style'][ $key ] );
+                                }
+                        }
+                        if ( empty( $attrs_array['style'] ) ) {
+                                unset( $attrs_array['style'] );
+                        }
+                }
 
-	/**
+                $class_parts = array_filter( array_map( 'sanitize_html_class', $class_parts ) );
+                $class_name  = trim( implode( ' ', $class_parts ) );
+
+                if ( '' !== $class_name ) {
+                        $attrs_array['className'] = $class_name;
+                }
+
+                $inline_style .= $typo_css . $border_css . $spacing_css;
+
+                $attrs = wp_json_encode( $attrs_array );
+
+                $block_content = sprintf(
+                        '<!-- wp:heading %s --><h%s%s class="%s"%s>%s</h%s><!-- /wp:heading -->' . "\n",
+                        $attrs,
+                        esc_html( $level ),
+                        $custom_id ? ' id="' . esc_attr( $custom_id ) . '"' : '',
+                        esc_attr( $class_name ),
+                        $inline_style ? ' style="' . esc_attr( $inline_style ) . '"' : '',
+                        esc_html( $title ),
+                        esc_html( $level )
+                );
+
+                if ( ! empty( $custom_css ) ) {
+                        Style_Parser::save_custom_css( $custom_css );
+                }
+
+                return $block_content;
+        }
+
+        /**
 	 * Check if a given color value is a Gutenberg preset slug.
 	 *
 	 * @param string $color Color value.

--- a/src/admin/widget/class-text-editor-widget-handler.php
+++ b/src/admin/widget/class-text-editor-widget-handler.php
@@ -22,48 +22,85 @@ class Text_Editor_Widget_Handler implements Widget_Handler_Interface {
 	 * @param array $element The Elementor element data.
 	 * @return string The Gutenberg block content.
 	 */
-	public function handle( array $element ): string {
-		$settings = $element['settings'] ?? array();
-		$text     = $settings['editor'] ?? '';
-		$color    = $settings['text_color'] ?? '';
-		$class    = ! empty( $color ) ? 'has-text-color' : '';
-		$style    = ! empty( $color ) ? sprintf( 'color:%s;', esc_attr( $color ) ) : '';
-		$custom_class = $settings['_css_classes'] ?? '';
-		$custom_id    = $settings['_element_id'] ?? '';
-		$custom_css   = $settings['custom_css'] ?? '';
+        public function handle( array $element ): string {
+                $settings     = $element['settings'] ?? array();
+                $text         = $settings['editor'] ?? '';
+                $color        = isset( $settings['text_color'] ) ? (string) $settings['text_color'] : '';
+                $custom_class = trim( (string) ( $settings['_css_classes'] ?? '' ) );
+                $custom_id    = $settings['_element_id'] ?? '';
+                $custom_css   = $settings['custom_css'] ?? '';
 
-		if ( isset( $settings['typography_text_transform'] ) ) {
-			$class .= ' has-text-transform-' . esc_attr( $settings['typography_text_transform'] );
-		}
+                $class_parts = array( 'wp-block-paragraph' );
+                if ( '' !== $color ) {
+                        $class_parts[] = 'has-text-color';
+                }
 
-		if ( ! empty( $custom_class ) ) {
-			$class .= ' ' . esc_attr( $custom_class );
-		}
-		$typography   = Style_Parser::parse_typography( $settings );
-		$style       .= $typography['style'];
-		$attrs_array  = array(
-			'style' => array(
-				'color'      => array( 'text' => $color ),
-				'typography' => $typography['attributes'],
-			),
-		);
-		$attrs_array  = array_merge_recursive( $attrs_array, Style_Parser::parse_spacing( $settings ) );
-		$attrs        = wp_json_encode( $attrs_array );
+                if ( ! empty( $settings['typography_text_transform'] ) ) {
+                        $class_parts[] = 'has-text-transform-' . sanitize_html_class( $settings['typography_text_transform'] );
+                }
 
-		$block_content  = sprintf(
-			'<!-- wp:html %s --><div class="wp-block-paragraph %s" id="%s" style="%s">%s</div><!-- /wp:html -->' . "\n",
-			$attrs,
-			$class,
-			$custom_id,
-			$style,
-			wp_kses_post( $text )
-		);
+                if ( '' !== $custom_class ) {
+                        $class_parts = array_merge( $class_parts, preg_split( '/\s+/', $custom_class ) ?: array() );
+                }
 
-		// Save custom CSS to the Customizer's Additional CSS
-		if ( ! empty( $custom_css ) ) {
-			Style_Parser::save_custom_css( $custom_css );
-		}
+                $typography    = Style_Parser::parse_typography( $settings );
+                $typo_attrs    = is_array( $typography['attributes'] ?? null ) ? $typography['attributes'] : array();
+                $typo_css      = is_string( $typography['style'] ?? null ) ? $typography['style'] : '';
+                $spacing       = Style_Parser::parse_spacing( $settings );
+                $spacing_attrs = is_array( $spacing['attributes'] ?? null ) ? $spacing['attributes'] : array();
+                $spacing_css   = is_string( $spacing['style'] ?? null ) ? $spacing['style'] : '';
 
-		return $block_content;
-	}
+                $attrs_array = array();
+                if ( ! empty( $typo_attrs ) ) {
+                        $attrs_array['style']['typography'] = $typo_attrs;
+                }
+
+                if ( ! empty( $spacing_attrs ) ) {
+                        $attrs_array['style']['spacing'] = $spacing_attrs;
+                }
+
+                if ( '' !== $color ) {
+                        $attrs_array['style']['color']['text'] = $color;
+                }
+
+                if ( isset( $attrs_array['style'] ) ) {
+                        foreach ( $attrs_array['style'] as $key => $value ) {
+                                if ( empty( $value ) ) {
+                                        unset( $attrs_array['style'][ $key ] );
+                                }
+                        }
+                        if ( empty( $attrs_array['style'] ) ) {
+                                unset( $attrs_array['style'] );
+                        }
+                }
+
+                $class_parts = array_filter( array_map( 'sanitize_html_class', $class_parts ) );
+                $class_name  = trim( implode( ' ', $class_parts ) );
+                if ( '' !== $class_name ) {
+                        $attrs_array['className'] = $class_name;
+                }
+
+                $inline_style = '';
+                if ( '' !== $color ) {
+                        $inline_style .= 'color:' . esc_attr( $color ) . ';';
+                }
+                $inline_style .= $typo_css . $spacing_css;
+
+                $attrs = ! empty( $attrs_array ) ? wp_json_encode( $attrs_array ) : '{}';
+
+                $block_content = sprintf(
+                        '<!-- wp:html %1$s --><div class="%2$s"%3$s%4$s>%5$s</div><!-- /wp:html -->' . "\n",
+                        $attrs,
+                        esc_attr( $class_name ),
+                        $custom_id ? ' id="' . esc_attr( $custom_id ) . '"' : '',
+                        $inline_style ? ' style="' . esc_attr( $inline_style ) . '"' : '',
+                        wp_kses_post( $text )
+                );
+
+                if ( ! empty( $custom_css ) ) {
+                        Style_Parser::save_custom_css( $custom_css );
+                }
+
+                return $block_content;
+        }
 }


### PR DESCRIPTION
## Summary
- extend the container classifier to recognize Elementor container_type "grid" and use grid_columns_grid sizing
- harden the style parser and block builder so typography, spacing, border and background values produce safe block attributes and inline CSS
- update heading, text editor and button widget handlers to defensively merge style data without emitting empty nodes or triggering array warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e58e94a7ac832f926f5fdee0dd8376