### PR TITLE
Improve Elementor container conversion and add smoke tests

### DIFF
--- a/src/admin/helper/class-style-parser.php
+++ b/src/admin/helper/class-style-parser.php
@@ -6,6 +6,8 @@
  */
 namespace Progressus\Gutenberg\Admin\Helper;
 
+use function sanitize_html_class;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -13,164 +15,371 @@ defined( 'ABSPATH' ) || exit;
  */
 class Style_Parser {
 
-	/**
-	 * Parse typography settings from Elementor settings.
-	 *
-	 * @param array $settings The Elementor settings array.
-	 * @return array Array containing 'attributes' and 'style' keys.
-	 */
-	public static function parse_typography( array $settings ): array {
-		$attrs = array();
-		$style = '';
+/**
+ * Parse typography settings from Elementor settings.
+ *
+ * @param array $settings The Elementor settings array.
+ *
+ * @return array{attributes:array, style:string}
+ */
+public static function parse_typography( array $settings ): array {
+$attributes   = array();
+$style_parts  = array();
+$fields       = array(
+'typography_font_family'     => array( 'attr' => 'fontFamily', 'css' => 'font-family' ),
+'typography_text_transform'  => array( 'attr' => 'textTransform', 'css' => 'text-transform' ),
+'typography_font_style'      => array( 'attr' => 'fontStyle', 'css' => 'font-style' ),
+'typography_font_weight'     => array( 'attr' => 'fontWeight', 'css' => 'font-weight' ),
+'typography_text_decoration' => array( 'attr' => 'textDecoration', 'css' => 'text-decoration' ),
+);
 
-		$typography_fields = array(
-			'typography_font_family'     => array( 'attr' => 'fontFamily', 'style' => 'font-family' ),
-			'typography_text_transform'  => array( 'attr' => 'textTransform', 'style' => 'text-transform' ),
-			'typography_font_size'       => array( 'attr' => 'fontSize', 'style' => 'font-size', 'is_array' => true ),
-			'typography_font_weight'     => array( 'attr' => 'fontWeight', 'style' => 'font-weight' ),
-			'typography_line_height'     => array( 'attr' => 'lineHeight', 'style' => 'line-height', 'is_array' => true ),
-			'typography_font_style'      => array( 'attr' => 'fontStyle', 'style' => 'font-style' ),
-			'typography_text_decoration' => array( 'attr' => 'textDecoration', 'style' => 'text-decoration' ),
-			'typography_letter_spacing'  => array( 'attr' => 'letterSpacing', 'style' => 'letter-spacing', 'is_array' => true ),
-			'typography_word_spacing'    => array( 'attr' => 'wordSpacing', 'style' => 'word-spacing', 'is_array' => true ),
-		);
+foreach ( $fields as $key => $map ) {
+$value = self::sanitize_scalar( $settings[ $key ] ?? null );
+if ( '' === $value ) {
+continue;
+}
 
-		foreach ( $typography_fields as $key => $field ) {
-			if ( ! isset( $settings[ $key ] ) ) {
-				continue;
-			}
+$attributes[ $map['attr'] ] = $value;
+$style_parts[]             = sprintf( '%s:%s;', $map['css'], $value );
+}
 
-			if ( ! empty( $field['is_array'] ) ) {
-				$size = $settings[ $key ]['size'] ?? '';
-				$unit = $settings[ $key ]['unit'] ?? ( 'typography_line_height' === $key ? '' : 'px' );
-				if ( '' !== $size && is_numeric( $size ) ) {
-					$value = $size . $unit;
-					$attrs[ $field['attr'] ] = $value;
-					$style .= sprintf( '%s:%s;', $field['style'], esc_attr( $value ) );
-				}
-			} else {
-				$value = $settings[ $key ];
-				if ( '' !== $value ) {
-					$attrs[ $field['attr'] ] = $value;
-					$style .= sprintf( '%s:%s;', $field['style'], esc_attr( $value ) );
-				}
-			}
-		}
+$dimensions = array(
+'typography_font_size'      => array( 'attr' => 'fontSize', 'css' => 'font-size', 'default_unit' => 'px' ),
+'typography_line_height'    => array( 'attr' => 'lineHeight', 'css' => 'line-height', 'default_unit' => '' ),
+'typography_letter_spacing' => array( 'attr' => 'letterSpacing', 'css' => 'letter-spacing', 'default_unit' => 'px' ),
+'typography_word_spacing'   => array( 'attr' => 'wordSpacing', 'css' => 'word-spacing', 'default_unit' => 'px' ),
+);
 
-		return array(
-			'attributes' => $attrs,
-			'style'      => $style,
-		);
-	}
+foreach ( $dimensions as $key => $map ) {
+$value = self::normalize_dimension( $settings[ $key ] ?? null, $map['default_unit'] );
+if ( null === $value ) {
+continue;
+}
 
-	/**
-	 * Parse spacing settings from Elementor settings.
-	 *
-	 * @param array $settings The Elementor settings array.
-	 * @return array Array containing 'attributes' and 'style' keys.
-	 */
-	public static function parse_spacing( array $settings ): array {
-		$attrs = array();
-		$style = '';
+$attributes[ $map['attr'] ] = $value;
+$style_parts[]             = sprintf( '%s:%s;', $map['css'], $value );
+}
 
-		foreach ( array( 'padding', 'margin' ) as $spacing ) {
-			$key = '_' . $spacing;
-			if ( ! isset( $settings[ $key ] ) || ! is_array( $settings[ $key ] ) ) {
-				continue;
-			}
+return array(
+'attributes' => $attributes,
+'style'      => implode( '', $style_parts ),
+);
+}
 
-			$unit = $settings[ $key ]['unit'] ?? 'px';
+/**
+ * Parse spacing settings from Elementor settings.
+ *
+ * @param array $settings Elementor settings array.
+ *
+ * @return array{attributes:array, style:string}
+ */
+public static function parse_spacing( array $settings ): array {
+$attributes  = array();
+$style_parts = array();
+$maps        = array(
+'_padding' => 'padding',
+'_margin'  => 'margin',
+'padding'  => 'padding',
+'margin'   => 'margin',
+);
 
-			foreach ( array( 'top', 'bottom', 'left', 'right' ) as $side ) {
-				if ( isset( $settings[ $key ][ $side ] ) && '' !== $settings[ $key ][ $side ] ) {
-					$value = $settings[ $key ][ $side ] . $unit;
-					$attrs[ $spacing ][ $side ] = $value;
-					$style .= sprintf( '%s-%s:%s;', $spacing, $side, esc_attr( $value ) );
-				}
-			}
-		}
+foreach ( $maps as $key => $type ) {
+$data = $settings[ $key ] ?? null;
+if ( ! is_array( $data ) ) {
+continue;
+}
 
-		return array(
-			'attributes' => $attrs ? : array(),
-			'style'      => $style,
-		);
-	}
+foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
+$value = self::extract_box_value( $data, $side );
+if ( null === $value ) {
+continue;
+}
 
-	/**
-	 * Parse border settings from Elementor settings.
-	 *
-	 * @param array $settings The Elementor settings array.
-	 * @return array Array containing 'attributes' and 'style' keys.
-	 */
-	public static function parse_border( array $settings ): array {
-		$attrs = array();
-		$style = '';
+$attributes[ $type ][ $side ] = $value;
+$style_parts[]               = sprintf( '%s-%s:%s;', $type, $side, $value );
+}
+}
 
-		// Map Elementor sides to Gutenberg sides.
-		$radius_map = array(
-			'top'    => array( 'topLeft', 'top-left' ),
-			'right'  => array( 'topRight', 'top-right' ),
-			'bottom' => array( 'bottomRight', 'bottom-right' ),
-			'left'   => array( 'bottomLeft', 'bottom-left' ),
-		);
+$gap_keys = array( 'gap', 'column_gap', 'gap_columns' );
+foreach ( $gap_keys as $gap_key ) {
+$gap_value = self::normalize_dimension( $settings[ $gap_key ] ?? null, 'px' );
+if ( null === $gap_value ) {
+continue;
+}
 
-		// Border radius.
-		if ( isset( $settings['_border_radius'] ) && is_array( $settings['_border_radius'] ) ) {
-			$unit = $settings['_border_radius']['unit'] ?? 'px';
-			foreach ( $radius_map as $el_side => $gb_side ) {
-				if ( isset( $settings['_border_radius'][ $el_side ] ) && $settings['_border_radius'][ $el_side ] !== '' ) {
-					$value = $settings['_border_radius'][ $el_side ] . $unit;
-					$attrs['radius'][ $gb_side[0] ] = $value;
-					$style .= sprintf( 'border-%s-radius:%s;', 
-						$gb_side[1],
-						esc_attr( $value )
-					);
-				}
-			}
-		}
+$attributes['blockGap'] = $gap_value;
+$style_parts[]          = sprintf( 'gap:%s;', $gap_value );
+break;
+}
 
-		// Border width + color per side.
-		if ( isset( $settings['_border_width'] ) && is_array( $settings['_border_width'] ) ) {
-			$unit = $settings['_border_width']['unit'] ?? 'px';
-			$color = ! empty( $settings['border_color'] ) ? strtolower( $settings['border_color'] ) : '';
+return array(
+'attributes' => $attributes,
+'style'      => implode( '', $style_parts ),
+);
+}
 
-			foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
-				if ( isset( $settings['_border_width'][ $side ] ) && $settings['_border_width'][ $side ] !== '' ) {
-					$width = $settings['_border_width'][ $side ] . $unit;
-					$attrs[ $side ]['width'] = $width;
-					$style .= sprintf( 'border-%s-width:%s;', $side, esc_attr( $width ) );
+/**
+ * Parse border settings safely.
+ *
+ * @param array $settings Elementor settings array.
+ *
+ * @return array{attributes:array, style:string}
+ */
+public static function parse_border( array $settings ): array {
+$attributes  = array();
+$style_parts = array();
 
-					if ( $color ) {
-						$attrs[ $side ]['color'] = $color;
-						$style .= sprintf( 'border-%s-color:%s;', $side, esc_attr( $color ) );
-					}
-				}
-			}
-		}
+$radius_sources = array( '_border_radius', 'border_radius' );
+foreach ( $radius_sources as $radius_key ) {
+$radius_data = $settings[ $radius_key ] ?? null;
+if ( ! is_array( $radius_data ) ) {
+continue;
+}
 
-		// Border style (solid, dashed, etc.)
-		if ( ! empty( $settings['_border_border'] ) ) {
-			$attrs['style'] = $settings['_border_border'];
-			$style .= 'border-style:' . esc_attr( $settings['_border_border'] ) . ';';
-		}
+$unit = self::sanitize_scalar( $radius_data['unit'] ?? 'px' );
+foreach ( array(
+'topLeft'     => 'top',
+'topRight'    => 'right',
+'bottomRight' => 'bottom',
+'bottomLeft'  => 'left',
+) as $attr_key => $side ) {
+$value = self::normalize_dimension( $radius_data[ $side ] ?? null, $unit );
+if ( null === $value ) {
+continue;
+}
 
-		return array(
-			'attributes' => $attrs ? : array(),
-			'style'      => $style,
-		);
-	}
+$attributes['radius'][ $attr_key ] = $value;
+$style_parts[]                    = sprintf( 'border-%s-radius:%s;', str_replace( array( 'Left', 'Right' ), array( 'left', 'right' ), strtolower( preg_replace( '/([A-Z])/', '-$1', $attr_key ) ) ), $value );
+}
+}
 
+$width_sources = array( '_border_width', 'border_width' );
+$color         = self::sanitize_color( $settings['border_color'] ?? $settings['_border_color'] ?? '' );
 
-	/**
-	 * Save custom CSS to the Customizer's Additional CSS.
-	 *
-	 * @param string $css The CSS string.
-	 */
-	public static function save_custom_css( string $css ) {
-		$customizer_css_post = wp_get_custom_css_post();
-		$existing_css        = $customizer_css_post ? $customizer_css_post->post_content : '';
-		$new_css             = $existing_css . "\n" . $css;
+foreach ( $width_sources as $width_key ) {
+$width_data = $settings[ $width_key ] ?? null;
+if ( ! is_array( $width_data ) ) {
+continue;
+}
 
-		wp_update_custom_css_post( $new_css );
-	}
+$unit = self::sanitize_scalar( $width_data['unit'] ?? 'px' );
+foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
+$value = self::normalize_dimension( $width_data[ $side ] ?? null, $unit );
+if ( null === $value ) {
+continue;
+}
+
+$attributes[ $side ]['width'] = $value;
+$style_parts[]               = sprintf( 'border-%s-width:%s;', $side, $value );
+
+if ( '' !== $color ) {
+$attributes[ $side ]['color'] = $color;
+$style_parts[]                = sprintf( 'border-%s-color:%s;', $side, $color );
+}
+}
+}
+
+$style_value = self::sanitize_scalar( $settings['_border_border'] ?? $settings['border_style'] ?? '' );
+if ( '' !== $style_value ) {
+$attributes['style'] = $style_value;
+$style_parts[]       = sprintf( 'border-style:%s;', $style_value );
+}
+
+return array(
+'attributes' => $attributes,
+'style'      => implode( '', $style_parts ),
+);
+}
+
+/**
+ * Parse container specific styles into block attributes.
+ *
+ * @param array $settings Elementor settings array.
+ *
+ * @return array
+ */
+public static function parse_container_styles( array $settings ): array {
+$attributes = array();
+
+$spacing = self::parse_spacing( $settings );
+if ( ! empty( $spacing['attributes'] ) ) {
+$attributes['style']['spacing'] = $spacing['attributes'];
+}
+
+$border = self::parse_border( $settings );
+if ( ! empty( $border['attributes'] ) ) {
+$attributes['style']['border'] = $border['attributes'];
+}
+
+$background = self::sanitize_color( $settings['background_color'] ?? $settings['_background_color'] ?? '' );
+if ( '' !== $background ) {
+if ( self::is_preset_slug( $background ) ) {
+$attributes['backgroundColor'] = $background;
+$attributes['className']      = self::append_class( $attributes['className'] ?? '', 'has-background' );
+} else {
+$attributes['style']['color']['background'] = $background;
+$attributes['className']                     = self::append_class( $attributes['className'] ?? '', 'has-background' );
+}
+}
+
+$custom_classes = self::sanitize_class_string( $settings['_css_classes'] ?? '' );
+if ( '' !== $custom_classes ) {
+$attributes['className'] = self::append_class( $attributes['className'] ?? '', $custom_classes );
+}
+
+return $attributes;
+}
+
+/**
+ * Determine if the supplied color is a preset slug.
+ *
+ * @param string $color Color string.
+ */
+private static function is_preset_slug( string $color ): bool {
+return '' !== $color && false === strpos( $color, '#' ) && 0 !== strpos( $color, 'rgb' );
+}
+
+/**
+ * Sanitize a scalar value from Elementor settings.
+ *
+ * @param mixed $value Raw value.
+ */
+private static function sanitize_scalar( $value ): string {
+if ( is_array( $value ) ) {
+return '';
+}
+
+$value = is_bool( $value ) ? ( $value ? '1' : '0' ) : (string) $value;
+
+return trim( $value );
+}
+
+/**
+ * Normalize color strings.
+ *
+ * @param mixed $value Potential color value.
+ */
+private static function sanitize_color( $value ): string {
+if ( is_array( $value ) ) {
+$value = $value['value'] ?? $value['color'] ?? '';
+}
+
+return strtolower( self::sanitize_scalar( $value ) );
+}
+
+/**
+ * Normalize Elementor dimension value.
+ *
+ * @param mixed  $value Raw value.
+ * @param string $default_unit Default unit when missing.
+ */
+private static function normalize_dimension( $value, string $default_unit ): ?string {
+if ( is_array( $value ) ) {
+if ( isset( $value['size'] ) ) {
+return self::normalize_dimension( $value['size'], $value['unit'] ?? $default_unit );
+}
+if ( isset( $value['value'] ) ) {
+return self::normalize_dimension( $value['value'], $value['unit'] ?? $default_unit );
+}
+}
+
+if ( null === $value || '' === $value ) {
+return null;
+}
+
+if ( is_numeric( $value ) ) {
+return $value . ( '' === $default_unit ? '' : $default_unit );
+}
+
+$value = trim( (string) $value );
+if ( '' === $value ) {
+return null;
+}
+
+if ( preg_match( '/[a-z%]+$/i', $value ) ) {
+return $value;
+}
+
+return $value . ( '' === $default_unit ? '' : $default_unit );
+}
+
+/**
+ * Extract padding/margin side values.
+ *
+ * @param array  $data Elementor box model array.
+ * @param string $side Side to extract.
+ */
+private static function extract_box_value( array $data, string $side ): ?string {
+if ( array_key_exists( $side, $data ) ) {
+return self::normalize_dimension( $data[ $side ], $data['unit'] ?? 'px' );
+}
+
+return null;
+}
+
+/**
+ * Append classes safely, ensuring no duplicates.
+ *
+ * @param string $existing Existing class list.
+ * @param string $new      New class or classes.
+ */
+private static function append_class( string $existing, string $new ): string {
+$existing_list = '' === $existing ? array() : preg_split( '/\s+/', $existing );
+$new_list      = preg_split( '/\s+/', $new );
+$combined      = array();
+
+foreach ( array_merge( (array) $existing_list, (array) $new_list ) as $class ) {
+$class = trim( (string) $class );
+if ( '' === $class ) {
+continue;
+}
+$combined[ $class ] = true;
+}
+
+return implode( ' ', array_keys( $combined ) );
+}
+
+/**
+ * Sanitize custom class string from Elementor.
+ *
+ * @param mixed $value Raw value.
+ */
+private static function sanitize_class_string( $value ): string {
+if ( ! is_string( $value ) ) {
+return '';
+}
+
+$classes = array();
+foreach ( preg_split( '/\s+/', $value ) as $class ) {
+$class = trim( $class );
+if ( '' === $class ) {
+continue;
+}
+$classes[] = sanitize_html_class( $class );
+}
+
+return implode( ' ', $classes );
+}
+
+/**
+ * Save custom CSS to the Customizer's Additional CSS store when available.
+ *
+ * @param string $css CSS string to append.
+ */
+public static function save_custom_css( string $css ): void {
+$css = trim( $css );
+if ( '' === $css ) {
+return;
+}
+
+if ( ! function_exists( 'wp_get_custom_css_post' ) || ! function_exists( 'wp_update_custom_css_post' ) ) {
+return;
+}
+
+$customizer_css_post = wp_get_custom_css_post();
+$existing_css        = $customizer_css_post ? (string) $customizer_css_post->post_content : '';
+$new_css             = rtrim( $existing_css ) . "\n" . $css;
+
+wp_update_custom_css_post( $new_css );
+}
 }

--- a/src/admin/layout/class-container-classifier.php
+++ b/src/admin/layout/class-container-classifier.php
@@ -20,64 +20,30 @@ class Container_Classifier {
 	 *
 	 * @return bool
 	 */
-	public static function is_grid( array $element ): bool {
-		$settings = $element['settings'] ?? array();
-		$child_count = isset( $element['elements'] ) && is_array( $element['elements'] ) ? count( $element['elements'] ) : 0;
+public static function is_grid( array $element ): bool {
+$settings    = is_array( $element['settings'] ?? null ) ? $element['settings'] : array();
+$child_count = isset( $element['elements'] ) && is_array( $element['elements'] ) ? count( $element['elements'] ) : 0;
 
-		if ( isset( $settings['layout'] ) && 'grid' === $settings['layout'] ) {
-			return true;
-		}
+if ( isset( $settings['container_type'] ) && 'grid' === $settings['container_type'] ) {
+return true;
+}
 
-		if ( isset( $settings['display'] ) && 'grid' === $settings['display'] ) {
-			return true;
-		}
+$grid_hints = array(
+'grid_columns',
+'grid_template_columns',
+'grid_auto_flow',
+'grid_columns_grid',
+'grid_rows_grid',
+);
 
-		if ( isset( $settings['grid_columns'] ) || isset( $settings['grid_template_columns'] ) || isset( $settings['grid_auto_flow'] ) ) {
-			return true;
-		}
+foreach ( $grid_hints as $hint ) {
+if ( isset( $settings[ $hint ] ) && '' !== $settings[ $hint ] ) {
+return true;
+}
+}
 
-		if ( isset( $settings['grid_row_gap'] ) || isset( $settings['gap_rows'] ) ) {
-			return true;
-		}
-
-		if ( $child_count > 4 ) {
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
-	 * Determine whether we should render a container as columns.
-	 *
-	 * @param array $element  Elementor container element.
-	 * @param array $children Children elements.
-	 *
-	 * @return bool
-	 */
-	public static function should_render_columns( array $element, array $children ): bool {
-		$child_count = count( $children );
-		if ( $child_count < 2 || $child_count > 4 ) {
-			return false;
-		}
-
-		if ( self::is_grid( $element ) ) {
-			return false;
-		}
-
-		$settings = $element['settings'] ?? array();
-		$direction = self::get_flex_direction( $settings );
-		if ( 'column' === $direction || 'column-reverse' === $direction ) {
-			return false;
-		}
-
-		$wrap = $settings['flex_wrap'] ?? $settings['flex_wrap_mobile'] ?? '';
-		if ( in_array( $wrap, array( 'wrap', 'wrap-reverse' ), true ) && $child_count > 3 ) {
-			return false;
-		}
-
-		return true;
-	}
+return $child_count > 4;
+}
 
 	/**
 	 * Infer a grid column count from Elementor settings.
@@ -87,40 +53,74 @@ class Container_Classifier {
 	 *
 	 * @return int
 	 */
-	public static function get_grid_column_count( array $element, int $child_count ): int {
-		$settings = $element['settings'] ?? array();
-		$possible_keys = array( 'grid_columns', 'columns', 'grid_columns_number', 'grid_template_columns' );
+public static function get_grid_column_count( array $element, int $child_count ): int {
+$child_count = max( 1, $child_count );
+$settings    = is_array( $element['settings'] ?? null ) ? $element['settings'] : array();
 
-		foreach ( $possible_keys as $key ) {
-			if ( empty( $settings[ $key ] ) ) {
-				continue;
-			}
+if ( isset( $settings['grid_columns_grid'] ) && is_array( $settings['grid_columns_grid'] ) ) {
+$size = $settings['grid_columns_grid']['size'] ?? null;
+if ( is_numeric( $size ) ) {
+return self::clamp_columns( (int) $size, $child_count );
+}
+}
 
-			$value = $settings[ $key ];
-			if ( is_array( $value ) ) {
-				$value = $value['size'] ?? reset( $value );
-			}
+$numeric_keys = array( 'grid_columns', 'columns', 'grid_columns_number' );
+foreach ( $numeric_keys as $key ) {
+$value = $settings[ $key ] ?? null;
+if ( null === $value || '' === $value ) {
+continue;
+}
 
-			$value = (int) $value;
-			if ( $value > 0 ) {
-				return min( max( 1, $value ), max( 1, $child_count ) );
-			}
-		}
+if ( is_array( $value ) ) {
+$value = $value['size'] ?? $value['value'] ?? null;
+}
 
-		if ( $child_count >= 4 ) {
-			return 4;
-		}
+if ( is_numeric( $value ) ) {
+return self::clamp_columns( (int) $value, $child_count );
+}
+}
 
-		if ( $child_count >= 3 ) {
-			return 3;
-		}
+$template = $settings['grid_template_columns'] ?? '';
+if ( is_string( $template ) && '' !== trim( $template ) ) {
+$template = strtolower( $template );
+if ( preg_match( '/repeat\((\d+)/', $template, $matches ) ) {
+return self::clamp_columns( (int) $matches[1], $child_count );
+}
+$columns = preg_split( '/\s+/', trim( $template ) );
+if ( is_array( $columns ) && count( $columns ) > 1 ) {
+return self::clamp_columns( count( $columns ), $child_count );
+}
+}
 
-		if ( $child_count > 0 ) {
-			return $child_count;
-		}
+return min( 4, $child_count );
+}
 
-		return 1;
-	}
+/**
+ * Determine if a container should be rendered as a flex row.
+ *
+ * @param array $element     Elementor container element.
+ * @param int   $child_count Number of child elements.
+ */
+public static function is_row( array $element, int $child_count ): bool {
+if ( $child_count < 2 || $child_count > 4 ) {
+return false;
+}
+
+if ( self::is_grid( $element ) ) {
+return false;
+}
+
+$settings   = is_array( $element['settings'] ?? null ) ? $element['settings'] : array();
+$direction  = self::get_flex_direction( $settings );
+$has_row    = in_array( $direction, array( 'row', 'row-reverse' ), true );
+$wrap_value = strtolower( (string) ( $settings['flex_wrap'] ?? $settings['flex_wrap_tablet'] ?? $settings['flex_wrap_mobile'] ?? '' ) );
+
+if ( $has_row ) {
+return true;
+}
+
+return '' === $direction && ( '' === $wrap_value || 'nowrap' !== $wrap_value );
+}
 
 	/**
 	 * Get the flex direction configured for a container.
@@ -129,14 +129,27 @@ class Container_Classifier {
 	 *
 	 * @return string
 	 */
-	public static function get_flex_direction( array $settings ): string {
-		$direction = $settings['flex_direction'] ?? $settings['direction'] ?? '';
+public static function get_flex_direction( array $settings ): string {
+$direction = $settings['flex_direction'] ?? $settings['direction'] ?? '';
+$direction = is_string( $direction ) ? strtolower( $direction ) : '';
 
-		$valid = array( 'row', 'row-reverse', 'column', 'column-reverse' );
-		if ( in_array( $direction, $valid, true ) ) {
-			return $direction;
-		}
+$valid = array( 'row', 'row-reverse', 'column', 'column-reverse' );
+if ( in_array( $direction, $valid, true ) ) {
+return $direction;
+}
 
-		return 'row';
-	}
+return '';
+}
+
+/**
+ * Clamp inferred column counts to sane limits.
+ *
+ * @param int $columns     Desired column count.
+ * @param int $child_count Total children.
+ */
+private static function clamp_columns( int $columns, int $child_count ): int {
+$columns = max( 1, $columns );
+$columns = min( $columns, $child_count );
+return max( 1, $columns );
+}
 }

--- a/src/admin/widget/class-button-widget-handler.php
+++ b/src/admin/widget/class-button-widget-handler.php
@@ -7,8 +7,14 @@
 
 namespace Progressus\Gutenberg\Admin\Widget;
 
-use Progressus\Gutenberg\Admin\Widget_Handler_Interface;
+use Progressus\Gutenberg\Admin\Helper\Block_Builder;
 use Progressus\Gutenberg\Admin\Helper\Style_Parser;
+use Progressus\Gutenberg\Admin\Widget_Handler_Interface;
+
+use function esc_attr;
+use function esc_url;
+use function sanitize_html_class;
+use function wp_kses_post;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -17,105 +23,100 @@ defined( 'ABSPATH' ) || exit;
  */
 class Button_Widget_Handler implements Widget_Handler_Interface {
 
-	/**
-	 * Handle conversion of Elementor button to Gutenberg block.
-	 *
-	 * @param array $element The Elementor element data.
-	 * @return string The Gutenberg block content.
-	 */
-	public function handle( array $element ): string {
-		$settings     = $element['settings'] ?? array();
-		$text         = $settings['text'] ?? '';
-		$url          = $settings['link']['url'] ?? '';
-		$custom_class = $settings['_css_classes'] ?? '';
-		$custom_id    = $settings['_element_id'] ?? '';
-		$custom_css   = $settings['custom_css'] ?? '';
+/**
+ * Handle conversion of Elementor button to Gutenberg block.
+ *
+ * @param array $element The Elementor element data.
+ * @return string The Gutenberg block content.
+ */
+public function handle( array $element ): string {
+$settings = is_array( $element['settings'] ?? null ) ? $element['settings'] : array();
+$text     = isset( $settings['text'] ) ? (string) $settings['text'] : '';
+$link     = is_array( $settings['link'] ?? null ) ? (string) ( $settings['link']['url'] ?? '' ) : '';
+$custom_class = isset( $settings['_css_classes'] ) ? trim( (string) $settings['_css_classes'] ) : '';
+$custom_id    = isset( $settings['_element_id'] ) ? trim( (string) $settings['_element_id'] ) : '';
+$custom_css   = isset( $settings['custom_css'] ) ? (string) $settings['custom_css'] : '';
+$text_color   = isset( $settings['button_text_color'] ) ? strtolower( (string) $settings['button_text_color'] ) : '';
+$background   = isset( $settings['background_color'] ) ? strtolower( (string) $settings['background_color'] ) : '';
 
-		$class = '';
-		if ( ! empty( $custom_class ) ) {
-			$class .= ' ' . esc_attr( $custom_class );
-		}
+$typography = Style_Parser::parse_typography( $settings );
+$spacing    = Style_Parser::parse_spacing( $settings );
+$border     = Style_Parser::parse_border( $settings );
 
-		$attrs_array = array();
-		$inline_style = '';
+$button_attributes = array();
+$inline_style_parts = array( $typography['style'], $spacing['style'], $border['style'] );
+$class_names        = array( 'wp-block-button__link', 'wp-element-button' );
 
-		if ( $url ) {
-			$attrs_array['url'] = esc_url( $url );
-		}
+if ( '' !== $link ) {
+$button_attributes['url'] = $link;
+}
 
-		if ( ! empty( $settings['button_text_color'] ) ) {
-			$txt = strtolower( $settings['button_text_color'] );
-			$class .= ' has-text-color has-link-color';
-			if ( $this->is_preset_color_slug( $txt ) ) {
-				$attrs_array['textColor'] = $txt;
-				$class .= ' has-text-color has-link-color';
-				$attrs_array['style']['elements']['link']['color']['text'] = 'var:preset|color|' . $txt;
-			} else {
-				$attrs_array['style']['color']['text'] = $txt;
-				$attrs_array['style']['elements']['link']['color']['text'] = $txt;
-				$inline_style .= 'color:' . $txt . ';';
-			}
+if ( ! empty( $typography['attributes'] ) ) {
+$button_attributes['style']['typography'] = $typography['attributes'];
+}
+if ( ! empty( $spacing['attributes'] ) ) {
+$button_attributes['style']['spacing'] = $spacing['attributes'];
+}
+if ( ! empty( $border['attributes'] ) ) {
+$button_attributes['style']['border'] = $border['attributes'];
+}
 
-		}
+if ( '' !== $text_color ) {
+if ( $this->is_preset_color_slug( $text_color ) ) {
+$button_attributes['textColor'] = $text_color;
+$button_attributes['style']['elements']['link']['color']['text'] = 'var:preset|color|' . $text_color;
+} else {
+$button_attributes['style']['color']['text']                  = $text_color;
+$button_attributes['style']['elements']['link']['color']['text'] = $text_color;
+$inline_style_parts[] = 'color:' . $text_color . ';';
+}
+$class_names[] = 'has-text-color';
+$class_names[] = 'has-link-color';
+}
 
-		if ( ! empty( $settings['background_color'] ) ) {
-			$bg = strtolower( $settings['background_color'] );
-			$class .= ' has-background';
-			if ( $this->is_preset_color_slug( $bg ) ) {
-				$attrs_array['backgroundColor'] = $bg;
-			} else {
-				$attrs_array['style']['color']['background'] = $bg;
-				$inline_style .= 'background-color:' . $bg . ';';
-			}
-		}
+if ( '' !== $background ) {
+if ( $this->is_preset_color_slug( $background ) ) {
+$button_attributes['backgroundColor'] = $background;
+} else {
+$button_attributes['style']['color']['background'] = $background;
+$inline_style_parts[] = 'background-color:' . $background . ';';
+}
+$class_names[] = 'has-background';
+}
 
-		// Typography, spacing, border.
-		$typography = Style_Parser::parse_typography( $settings );
-		$spacing    = Style_Parser::parse_spacing( $settings );
-		$border     = Style_Parser::parse_border( $settings );
+if ( '' !== $custom_class ) {
+foreach ( preg_split( '/\s+/', $custom_class ) as $class ) {
+$class = trim( $class );
+if ( '' !== $class ) {
+$class_names[] = sanitize_html_class( $class );
+}
+}
+}
 
-		if ( ! empty( $typography['attributes'] ) ) {
-			$attrs_array['style']['typography'] = $typography['attributes'];
-		}
-		if ( ! empty( $spacing['attributes'] ) ) {
-			$attrs_array['style']['spacing'] = $spacing['attributes'];
-		}
-		if ( ! empty( $border['attributes'] ) ) {
-			$attrs_array['style']['border'] = $border['attributes'];
-		}
+$inline_style = implode( '', array_filter( $inline_style_parts ) );
 
-		// Inline style fallback (optional, safe for editor).
-		$inline_style .= $typography['style'] . $spacing['style'] . $border['style'];
+if ( '' !== $custom_css ) {
+Style_Parser::save_custom_css( $custom_css );
+}
 
-		// Encode attributes.
-		$attrs = wp_json_encode( $attrs_array );
+$anchor_attributes = '' !== $custom_id ? ' id="' . esc_attr( $custom_id ) . '"' : '';
+$anchor_attributes .= ! empty( $class_names ) ? ' class="' . esc_attr( implode( ' ', array_unique( $class_names ) ) ) . '"' : '';
+$anchor_attributes .= '' !== $inline_style ? ' style="' . esc_attr( $inline_style ) . '"' : '';
+$anchor_attributes .= '' !== $link ? ' href="' . esc_url( $link ) . '"' : '';
 
-		// Build block content.
-		$block_content = sprintf(
-			'<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button %1s --><div class="wp-block-button"><a id="%2s" class="wp-block-button__link %3s wp-element-button"%4s%5s>%6s</a></div><!-- /wp:button --></div><!-- /wp:buttons -->' . "\n",
-			$attrs,
-			esc_attr( $custom_id ),
-			esc_attr( $class ),
-			$inline_style ? ' style="' . esc_attr( $inline_style ) . '"' : '',
-			$url ? ' href="' . esc_url( $url ) . '"' : '',
-			esc_html( $text )
-		);
+$anchor_html = sprintf( '<a%s>%s</a>', $anchor_attributes, wp_kses_post( $text ) );
 
-		// Save custom CSS if any.
-		if ( ! empty( $custom_css ) ) {
-			Style_Parser::save_custom_css( $custom_css );
-		}
+$button_block = Block_Builder::build( 'core/button', $button_attributes, $anchor_html );
 
-		return $block_content;
-	}
+return Block_Builder::build( 'core/buttons', array(), $button_block );
+}
 
-	/**
-	 * Check if a given color value is a Gutenberg preset slug.
-	 *
-	 * @param string $color Color value.
-	 * @return bool
-	 */
-	private function is_preset_color_slug( string $color ): bool {
-		return ! empty( $color ) && strpos( $color, '#' ) === false;
-	}
+/**
+ * Check if a given color value is a Gutenberg preset slug.
+ *
+ * @param string $color Color value.
+ */
+private function is_preset_color_slug( string $color ): bool {
+return '' !== $color && false === strpos( $color, '#' );
+}
 }

--- a/src/admin/widget/class-heading-widget-handler.php
+++ b/src/admin/widget/class-heading-widget-handler.php
@@ -7,8 +7,13 @@
 
 namespace Progressus\Gutenberg\Admin\Widget;
 
-use Progressus\Gutenberg\Admin\Widget_Handler_Interface;
+use Progressus\Gutenberg\Admin\Helper\Block_Builder;
 use Progressus\Gutenberg\Admin\Helper\Style_Parser;
+use Progressus\Gutenberg\Admin\Widget_Handler_Interface;
+
+use function esc_attr;
+use function sanitize_html_class;
+use function wp_kses_post;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -17,97 +22,137 @@ defined( 'ABSPATH' ) || exit;
  */
 class Heading_Widget_Handler implements Widget_Handler_Interface {
 
-	/**
-	 * Handle conversion of Elementor heading to Gutenberg block.
-	 *
-	 * @param array $element The Elementor element data.
-	 * @return string The Gutenberg block content.
-	 */
-	public function handle( array $element ): string {
-		$settings      = $element['settings'] ?? array();
-		$title         = $settings['title'] ?? '';
-		$level         = str_split( $settings['header_size'] )[1] ?? 2;
-		$text_color    = ! empty( $settings['title_color'] ) ? strtolower( $settings['title_color'] ) : '';
-		$custom_class  = $settings['_css_classes'] ?? '';
-		$unique_class  = 'heading-' . uniqid();
-		$custom_id     = $settings['_element_id'] ?? '';
-		$custom_css    = $settings['custom_css'] ?? '';
-		$custom_class .= ' ' . $unique_class;
+/**
+ * Handle conversion of Elementor heading to Gutenberg block.
+ *
+ * @param array $element The Elementor element data.
+ * @return string The Gutenberg block content.
+ */
+public function handle( array $element ): string {
+$settings = is_array( $element['settings'] ?? null ) ? $element['settings'] : array();
+$title    = isset( $settings['title'] ) ? (string) $settings['title'] : '';
+$level    = $this->resolve_heading_level( $settings['header_size'] ?? '' );
 
-		$class = 'wp-block-heading';
+$attributes         = array( 'level' => $level );
+$inline_style_parts = array();
+$class_names        = array();
+$element_classes    = array( 'wp-block-heading' );
+$custom_id          = isset( $settings['_element_id'] ) ? trim( (string) $settings['_element_id'] ) : '';
+$custom_css         = isset( $settings['custom_css'] ) ? (string) $settings['custom_css'] : '';
+$custom_class       = isset( $settings['_css_classes'] ) ? trim( (string) $settings['_css_classes'] ) : '';
+$text_color         = isset( $settings['title_color'] ) ? strtolower( (string) $settings['title_color'] ) : '';
+$text_transform     = isset( $settings['typography_text_transform'] ) ? trim( (string) $settings['typography_text_transform'] ) : '';
 
-		// Handle text transform.
-		if ( ! empty( $settings['typography_text_transform'] ) ) {
-			$class .= 'has-text-transform-' . esc_attr( $settings['typography_text_transform'] );
-		}
-		if ( ! empty( $custom_class ) ) {
-			$class .= ' ' . esc_attr( $custom_class );
-		}
+if ( '' !== $text_transform ) {
+$class_names[]   = 'has-text-transform-' . sanitize_html_class( $text_transform );
+$element_classes[] = 'has-text-transform-' . sanitize_html_class( $text_transform );
+}
 
-		$typography  = Style_Parser::parse_typography( $settings );
-		$border      = Style_Parser::parse_border( $settings );
-		$spacing	 = Style_Parser::parse_spacing( $settings );
+if ( '' !== $custom_class ) {
+foreach ( preg_split( '/\s+/', $custom_class ) as $class ) {
+$class = trim( $class );
+if ( '' !== $class ) {
+$class_names[]     = sanitize_html_class( $class );
+$element_classes[] = sanitize_html_class( $class );
+}
+}
+}
 
-		$attrs_array['level'] = (int) $level;
-		// Handle text + link color.
-		$inline_style = '';
-		if ( $this->is_preset_color_slug( $text_color ) ) {
-			// Preset slug.
-			$attrs_array['textColor'] = $text_color;
-			$attrs_array['style']['elements']['link']['color']['text'] = 'var:preset|color|' . $text_color;
-			$class .= ' has-text-color has-link-color';
-		} elseif ( ! empty( $text_color ) ) {
-			// Raw hex.
-			$attrs_array['style']['color']['text'] = $text_color;
-			$attrs_array['style']['elements']['link']['color']['text'] = $text_color;
-			$class .= ' has-text-color has-link-color';
+$typography = Style_Parser::parse_typography( $settings );
+$spacing    = Style_Parser::parse_spacing( $settings );
+$border     = Style_Parser::parse_border( $settings );
 
-			// Add inline style for both text + link.
-			$inline_style .= 'color:' . esc_attr( $text_color ) . ';';
-		}
+if ( ! empty( $typography['attributes'] ) ) {
+$attributes['style']['typography'] = $typography['attributes'];
+}
+if ( ! empty( $spacing['attributes'] ) ) {
+$attributes['style']['spacing'] = $spacing['attributes'];
+}
+if ( ! empty( $border['attributes'] ) ) {
+$attributes['style']['border'] = $border['attributes'];
+}
 
-		$attrs_array['className'] = trim( $class );
+$inline_style_parts[] = $typography['style'];
+$inline_style_parts[] = $spacing['style'];
+$inline_style_parts[] = $border['style'];
 
-		if ( ! empty( $typography['attributes'] ) ) {
-			$attrs_array['style']['typography'] = $typography['attributes'];
-		}
-		if ( ! empty( $spacing['attributes'] ) ) {
-			$attrs_array['style']['spacing'] = $spacing['attributes'];
-		}
-		if ( ! empty( $border['attributes'] ) ) {
-			$attrs_array['style']['border'] = $border['attributes'];
-		}
-		$inline_style .= $typography['style'] . $border['style'] . $spacing['style'];
-		// Encode block attributes.
-		$attrs = wp_json_encode( $attrs_array );
+if ( '' !== $text_color ) {
+if ( $this->is_preset_color_slug( $text_color ) ) {
+$attributes['textColor'] = $text_color;
+$attributes['style']['elements']['link']['color']['text'] = 'var:preset|color|' . $text_color;
+} else {
+$attributes['style']['color']['text']                  = $text_color;
+$attributes['style']['elements']['link']['color']['text'] = $text_color;
+$inline_style_parts[] = 'color:' . $text_color . ';';
+}
+$class_names[]     = 'has-text-color';
+$class_names[]     = 'has-link-color';
+$element_classes[] = 'has-text-color';
+$element_classes[] = 'has-link-color';
+}
 
-		// Build block output.
-		$block_content = sprintf(
-			'<!-- wp:heading %s --><h%s id="%s" class="%s"%s>%s</h%s><!-- /wp:heading -->' . "\n",
-			$attrs,
-			esc_html( $level ),
-			esc_attr( $custom_id ),
-			esc_attr( $class ),
-			$inline_style ? ' style="' . esc_attr( $inline_style ) . '"' : '',
-			esc_html( $title ),
-			esc_html( $level )
-		);
+if ( ! empty( $attributes['style']['color']['text'] ) && ! in_array( 'has-text-color', $class_names, true ) ) {
+$class_names[]     = 'has-text-color';
+$element_classes[] = 'has-text-color';
+}
 
-		// Save custom CSS if any.
-		if ( ! empty( $custom_css ) ) {
-			Style_Parser::save_custom_css( $custom_css );
-		}
+if ( ! empty( $attributes['style']['elements']['link']['color']['text'] ) && ! in_array( 'has-link-color', $class_names, true ) ) {
+$class_names[]     = 'has-link-color';
+$element_classes[] = 'has-link-color';
+}
 
-		return $block_content;
-	}
+if ( ! empty( $class_names ) ) {
+$attributes['className'] = implode( ' ', array_unique( $class_names ) );
+}
 
-	/**
-	 * Check if a given color value is a Gutenberg preset slug.
-	 *
-	 * @param string $color Color value.
-	 * @return bool
-	 */
-	private function is_preset_color_slug( string $color ): bool {
-		return ! empty( $color ) && strpos( $color, '#' ) === false;
-	}
+if ( '' !== $custom_id ) {
+$attributes['anchor'] = $custom_id;
+}
+
+$inline_style = implode( '', array_filter( $inline_style_parts ) );
+$element_classes = array_unique( $element_classes );
+
+$heading_markup = sprintf(
+'<h%d%s%s%s>%s</h%d>',
+$level,
+'' !== $custom_id ? ' id="' . esc_attr( $custom_id ) . '"' : '',
+! empty( $element_classes ) ? ' class="' . esc_attr( implode( ' ', $element_classes ) ) . '"' : '',
+'' !== $inline_style ? ' style="' . esc_attr( $inline_style ) . '"' : '',
+wp_kses_post( $title ),
+$level
+);
+
+if ( '' !== $custom_css ) {
+Style_Parser::save_custom_css( $custom_css );
+}
+
+return Block_Builder::build( 'core/heading', $attributes, $heading_markup );
+}
+
+/**
+ * Check if a given color value is a Gutenberg preset slug.
+ *
+ * @param string $color Color value.
+ * @return bool
+ */
+private function is_preset_color_slug( string $color ): bool {
+return '' !== $color && false === strpos( $color, '#' );
+}
+
+/**
+ * Resolve heading level from Elementor header size setting.
+ *
+ * @param mixed $header_size Elementor header size.
+ */
+private function resolve_heading_level( $header_size ): int {
+if ( is_string( $header_size ) && preg_match( '/h([1-6])/', strtolower( $header_size ), $matches ) ) {
+return (int) $matches[1];
+}
+
+if ( is_numeric( $header_size ) ) {
+return max( 1, min( 6, (int) $header_size ) );
+}
+
+return 2;
+}
 }

--- a/src/admin/widget/class-image-widget-handler.php
+++ b/src/admin/widget/class-image-widget-handler.php
@@ -7,9 +7,15 @@
 
 namespace Progressus\Gutenberg\Admin\Widget;
 
-use Progressus\Gutenberg\Admin\Widget_Handler_Interface;
+use Progressus\Gutenberg\Admin\Helper\Block_Builder;
 use Progressus\Gutenberg\Admin\Helper\File_Upload_Service;
 use Progressus\Gutenberg\Admin\Helper\Style_Parser;
+use Progressus\Gutenberg\Admin\Widget_Handler_Interface;
+
+use function esc_attr;
+use function esc_url;
+use function sanitize_html_class;
+use function wp_kses_post;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -17,120 +23,185 @@ defined( 'ABSPATH' ) || exit;
  * Widget handler for Elementor image widget.
  */
 class Image_Widget_Handler implements Widget_Handler_Interface {
-	/**
-	 * Handle conversion of Elementor image to Gutenberg block.
-	 *
-	 * @param array $element The Elementor element data.
-	 * @return string The Gutenberg block content.
-	 */
-	public function handle( array $element ): string {
-		$settings      = $element['settings'] ?? array();
-		$url           = $settings['image']['url'] ?? '';
-		$alt           = $settings['image']['alt'] ?? '';
-		$new_url       = File_Upload_Service::download_and_upload( $url ) ?? $url;
-		$attachment_id = ! empty( $new_url ) ? attachment_url_to_postid( $new_url ) : 0;
-		$custom_class  = $settings['_css_classes'] ?? '';
-		$custom_id     = $settings['_element_id'] ?? '';
-		$custom_css    = $settings['custom_css'] ?? '';
-		$size_slug     = 'full';
 
-		// Spacing.
-		$spacing = Style_Parser::parse_spacing( $settings );
+/**
+ * Handle conversion of Elementor image to Gutenberg block.
+ *
+ * @param array $element The Elementor element data.
+ * @return string The Gutenberg block content.
+ */
+public function handle( array $element ): string {
+$settings    = is_array( $element['settings'] ?? null ) ? $element['settings'] : array();
+$image       = is_array( $settings['image'] ?? null ) ? $settings['image'] : array();
+$image_url   = isset( $image['url'] ) ? (string) $image['url'] : '';
+$alt_text    = isset( $image['alt'] ) ? (string) $image['alt'] : '';
+$attachment  = isset( $image['id'] ) ? (int) $image['id'] : 0;
+$custom_id   = isset( $settings['_element_id'] ) ? trim( (string) $settings['_element_id'] ) : '';
+$custom_css  = isset( $settings['custom_css'] ) ? (string) $settings['custom_css'] : '';
+$custom_class = isset( $settings['_css_classes'] ) ? trim( (string) $settings['_css_classes'] ) : '';
+$align       = isset( $settings['align'] ) ? trim( (string) $settings['align'] ) : '';
+$caption     = isset( $settings['caption'] ) ? (string) $settings['caption'] : '';
 
-		$border_width  = $settings['image_border_width'] ?? array();
-		$border_radius = $settings['image_border_radius'] ?? array();
+if ( '' !== $image_url && function_exists( 'download_url' ) ) {
+$uploaded = File_Upload_Service::download_and_upload( $image_url );
+if ( null !== $uploaded ) {
+$image_url = $uploaded;
+if ( function_exists( 'attachment_url_to_postid' ) ) {
+$attachment = attachment_url_to_postid( $image_url );
+}
+}
+}
 
-		$border_attr      = array();
-		$border_style_css = '';
+$spacing = Style_Parser::parse_spacing( $settings );
+$border  = Style_Parser::parse_border( $settings );
 
-		if ( ! empty( $border_width['top'] ) ) {
-			$border_attr['width'] = $border_width['top'] . $border_width['unit'];
-			$border_style_css .= 'border-width:' . esc_attr( $border_width['top'] . $border_width['unit'] ) . ';';
-		}
-		if ( ! empty( $border_radius['top'] ) ) {
-			$border_attr['radius'] = $border_radius['top'] . $border_radius['unit'];
-			$border_style_css .= 'border-radius:' . esc_attr( $border_radius['top'] . $border_radius['unit'] ) . ';';
-		}
+$image_attrs = array(
+'sizeSlug'        => 'full',
+'linkDestination' => $this->map_link_destination( $settings ),
+);
 
-		// Build attributes.
-		$attrs_array = array(
-			'id'              => $attachment_id,
-			'sizeSlug'        => $size_slug,
-			'linkDestination' => $settings['link_to'] === 'custom' ? 'custom' : 'none',
-			'className'       => 'is-style-default ' . trim( $custom_class ),
-		);
+if ( $attachment > 0 ) {
+$image_attrs['id'] = $attachment;
+}
+if ( '' !== $image_url ) {
+$image_attrs['url'] = $image_url;
+}
+if ( '' !== $align ) {
+$image_attrs['align'] = $align;
+}
+if ( '' !== $custom_class ) {
+$image_attrs['className'] = $this->sanitize_class_string( $custom_class );
+}
 
-		if ( ! empty( $settings['align'] ) ) {
-			$custom_class .= ' align' . esc_attr( $settings['align'] );
-			$attrs_array['align'] = $settings['align'];
-		}
+if ( ! empty( $spacing['attributes'] ) ) {
+$image_attrs['style']['spacing'] = $spacing['attributes'];
+}
+if ( ! empty( $border['attributes'] ) ) {
+$image_attrs['style']['border'] = $border['attributes'];
+}
 
-		// Width from Elementor.
-		if ( isset( $settings['width']['size'] ) && '' !== $settings['width']['size'] ) {
-			$attrs_array['width'] = $settings['width']['size'] . ( $settings['width']['unit'] ?? 'px' );
-		}
+$figure_classes = array( 'wp-block-image' );
+if ( '' !== $align ) {
+$figure_classes[] = 'align' . sanitize_html_class( $align );
+}
+if ( '' !== $custom_class ) {
+foreach ( preg_split( '/\s+/', $custom_class ) as $class ) {
+$class = trim( $class );
+if ( '' !== $class ) {
+$figure_classes[] = sanitize_html_class( $class );
+}
+}
+}
 
-		if ( ! empty( $spacing['attributes'] ) ) {
-			$attrs_array['style']['spacing'] = $spacing['attributes'];
-		}
-		if ( ! empty( $border_attr ) ) {
-			$attrs_array['style']['border'] = $border_attr;
-		}
+$figure_style_parts = array( $spacing['style'], $border['style'] );
+$img_style_parts    = array();
 
-		// Classes for figure.
-		$figure_class = 'wp-block-image size-' . $size_slug;
-		if ( isset( $attrs_array['width'] ) ) {
-			$figure_class .= ' is-resized';
-		}
-		if ( ! empty( $border_attr ) ) {
-			$figure_class .= ' has-custom-border';
-		}
-		$figure_class .= ' is-style-default ' . trim( $custom_class );
+$width = $this->normalize_dimension( $settings['width'] ?? null );
+if ( null !== $width ) {
+$image_attrs['width'] = $width;
+$figure_classes[]     = 'is-resized';
+$img_style_parts[]     = 'width:' . $width . ';';
+}
 
-		// Inline style for <figure>.
-		$figure_style = $spacing['style'];
+$img_attributes = array();
+if ( $attachment > 0 ) {
+$img_attributes[] = 'class="wp-image-' . esc_attr( (string) $attachment ) . '"';
+}
+if ( ! empty( $img_style_parts ) ) {
+$img_attributes[] = 'style="' . esc_attr( implode( '', $img_style_parts ) ) . '"';
+}
 
-		// Inline style for <img>.
-		$img_style = $border_style_css;
-		if ( isset( $attrs_array['width'] ) ) {
-			$img_style .= 'width:' . esc_attr( $attrs_array['width'] ) . ';';
-		}
+$img_html = sprintf(
+'<img src="%s" alt="%s"%s />',
+esc_url( $image_url ),
+esc_attr( $alt_text ),
+$img_attributes ? ' ' . implode( ' ', $img_attributes ) : ''
+);
 
-		// Encode attrs.
-		$attrs = wp_json_encode( $attrs_array );
+if ( 'custom' === ( $settings['link_to'] ?? '' ) && ! empty( $settings['link']['url'] ?? '' ) ) {
+$img_html = sprintf( '<a href="%s">%s</a>', esc_url( (string) $settings['link']['url'] ), $img_html );
+}
 
-		// <img> tag.
-		$img_tag = sprintf(
-			'<img src="%s" alt="%s" class="wp-image-%d"%s />',
-			esc_url( $new_url ),
-			esc_attr( $alt ),
-			esc_attr( $attachment_id ),
-			$img_style ? ' style="' . esc_attr( $img_style ) . '"' : ''
-		);
+if ( '' !== $caption ) {
+$img_html .= sprintf( '<figcaption>%s</figcaption>', wp_kses_post( $caption ) );
+}
 
-		// Wrap with <a> if link_to = custom.
-		if ( $settings['link_to'] === 'custom' && ! empty( $settings['link']['url'] ) ) {
-			$img_tag = sprintf(
-				'<a href="%s">%s</a>',
-				esc_url( $settings['link']['url'] ),
-				$img_tag
-			);
-		}
+$figure_style = implode( '', array_filter( $figure_style_parts ) );
+$figure_attr  = array();
+if ( '' !== $custom_id ) {
+$figure_attr[] = 'id="' . esc_attr( $custom_id ) . '"';
+}
+$figure_attr[] = 'class="' . esc_attr( implode( ' ', array_unique( $figure_classes ) ) ) . '"';
+if ( '' !== $figure_style ) {
+$figure_attr[] = 'style="' . esc_attr( $figure_style ) . '"';
+}
 
-		// Final block.
-		$block_content = sprintf(
-			'<!-- wp:image %1s --><figure id="%2s" class="%3s"%4s>%5s</figure><!-- /wp:image -->' . "\n",
-			$attrs,
-			esc_attr( $custom_id ),
-			esc_attr( trim( $figure_class ) ),
-			$figure_style ? ' style="' . esc_attr( $figure_style ) . '"' : '',
-			$img_tag
-		);
+$figure_html = sprintf( '<figure %s>%s</figure>', implode( ' ', array_filter( $figure_attr ) ), $img_html );
 
-		if ( ! empty( $custom_css ) ) {
-			Style_Parser::save_custom_css( $custom_css );
-		}
+if ( '' !== $custom_css ) {
+Style_Parser::save_custom_css( $custom_css );
+}
 
-		return $block_content;
-	}
+return Block_Builder::build( 'core/image', $image_attrs, $figure_html );
+}
+
+/**
+ * Map Elementor link destination to Gutenberg setting.
+ *
+ * @param array $settings Elementor settings.
+ */
+private function map_link_destination( array $settings ): string {
+$link_to = isset( $settings['link_to'] ) ? (string) $settings['link_to'] : 'none';
+if ( 'custom' === $link_to ) {
+return 'custom';
+}
+if ( 'media' === $link_to ) {
+return 'media';
+}
+return 'none';
+}
+
+/**
+ * Normalize dimension values from Elementor settings.
+ *
+ * @param mixed $value Raw value.
+ */
+private function normalize_dimension( $value ): ?string {
+if ( is_array( $value ) ) {
+if ( isset( $value['size'] ) ) {
+return $this->normalize_dimension( $value['size'] . ( $value['unit'] ?? 'px' ) );
+}
+if ( isset( $value['value'] ) ) {
+return $this->normalize_dimension( $value['value'] . ( $value['unit'] ?? 'px' ) );
+}
+}
+
+if ( null === $value ) {
+return null;
+}
+
+$value = trim( (string) $value );
+if ( '' === $value ) {
+return null;
+}
+
+return $value;
+}
+
+/**
+ * Sanitize custom class strings.
+ *
+ * @param string $class_string Raw class string.
+ */
+private function sanitize_class_string( string $class_string ): string {
+$classes = array();
+foreach ( preg_split( '/\s+/', $class_string ) as $class ) {
+$class = trim( $class );
+if ( '' !== $class ) {
+$classes[] = sanitize_html_class( $class );
+}
+}
+
+return implode( ' ', $classes );
+}
 }

--- a/src/admin/widget/class-text-editor-widget-handler.php
+++ b/src/admin/widget/class-text-editor-widget-handler.php
@@ -7,8 +7,13 @@
 
 namespace Progressus\Gutenberg\Admin\Widget;
 
-use Progressus\Gutenberg\Admin\Widget_Handler_Interface;
+use Progressus\Gutenberg\Admin\Helper\Block_Builder;
 use Progressus\Gutenberg\Admin\Helper\Style_Parser;
+use Progressus\Gutenberg\Admin\Widget_Handler_Interface;
+
+use function esc_attr;
+use function sanitize_html_class;
+use function wp_kses_post;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -16,54 +21,83 @@ defined( 'ABSPATH' ) || exit;
  * Widget handler for Elementor text-editor widget.
  */
 class Text_Editor_Widget_Handler implements Widget_Handler_Interface {
-	/**
-	 * Handle conversion of Elementor text-editor to Gutenberg block.
-	 *
-	 * @param array $element The Elementor element data.
-	 * @return string The Gutenberg block content.
-	 */
-	public function handle( array $element ): string {
-		$settings = $element['settings'] ?? array();
-		$text     = $settings['editor'] ?? '';
-		$color    = $settings['text_color'] ?? '';
-		$class    = ! empty( $color ) ? 'has-text-color' : '';
-		$style    = ! empty( $color ) ? sprintf( 'color:%s;', esc_attr( $color ) ) : '';
-		$custom_class = $settings['_css_classes'] ?? '';
-		$custom_id    = $settings['_element_id'] ?? '';
-		$custom_css   = $settings['custom_css'] ?? '';
 
-		if ( isset( $settings['typography_text_transform'] ) ) {
-			$class .= ' has-text-transform-' . esc_attr( $settings['typography_text_transform'] );
-		}
+/**
+ * Handle conversion of Elementor text-editor to Gutenberg block.
+ *
+ * @param array $element The Elementor element data.
+ * @return string The Gutenberg block content.
+ */
+public function handle( array $element ): string {
+$settings = is_array( $element['settings'] ?? null ) ? $element['settings'] : array();
+$content  = isset( $settings['editor'] ) ? (string) $settings['editor'] : '';
+$custom_id    = isset( $settings['_element_id'] ) ? trim( (string) $settings['_element_id'] ) : '';
+$custom_css   = isset( $settings['custom_css'] ) ? (string) $settings['custom_css'] : '';
+$custom_class = isset( $settings['_css_classes'] ) ? trim( (string) $settings['_css_classes'] ) : '';
+$text_color   = isset( $settings['text_color'] ) ? strtolower( (string) $settings['text_color'] ) : '';
 
-		if ( ! empty( $custom_class ) ) {
-			$class .= ' ' . esc_attr( $custom_class );
-		}
-		$typography   = Style_Parser::parse_typography( $settings );
-		$style       .= $typography['style'];
-		$attrs_array  = array(
-			'style' => array(
-				'color'      => array( 'text' => $color ),
-				'typography' => $typography['attributes'],
-			),
-		);
-		$attrs_array  = array_merge_recursive( $attrs_array, Style_Parser::parse_spacing( $settings ) );
-		$attrs        = wp_json_encode( $attrs_array );
+$typography = Style_Parser::parse_typography( $settings );
+$spacing    = Style_Parser::parse_spacing( $settings );
+$border     = Style_Parser::parse_border( $settings );
 
-		$block_content  = sprintf(
-			'<!-- wp:html %s --><div class="wp-block-paragraph %s" id="%s" style="%s">%s</div><!-- /wp:html -->' . "\n",
-			$attrs,
-			$class,
-			$custom_id,
-			$style,
-			wp_kses_post( $text )
-		);
+$class_names = array( 'wp-block-paragraph' );
+if ( '' !== $custom_class ) {
+foreach ( preg_split( '/\s+/', $custom_class ) as $class ) {
+$class = trim( $class );
+if ( '' !== $class ) {
+$class_names[] = sanitize_html_class( $class );
+}
+}
+}
 
-		// Save custom CSS to the Customizer's Additional CSS
-		if ( ! empty( $custom_css ) ) {
-			Style_Parser::save_custom_css( $custom_css );
-		}
+$inline_style_parts = array( $typography['style'], $spacing['style'], $border['style'] );
+$attributes         = array();
 
-		return $block_content;
-	}
+if ( ! empty( $typography['attributes'] ) ) {
+$attributes['style']['typography'] = $typography['attributes'];
+}
+if ( ! empty( $spacing['attributes'] ) ) {
+$attributes['style']['spacing'] = $spacing['attributes'];
+}
+if ( ! empty( $border['attributes'] ) ) {
+$attributes['style']['border'] = $border['attributes'];
+}
+
+if ( '' !== $text_color ) {
+if ( $this->is_preset_color_slug( $text_color ) ) {
+$attributes['textColor'] = $text_color;
+$attributes['style']['elements']['link']['color']['text'] = 'var:preset|color|' . $text_color;
+} else {
+$attributes['style']['color']['text']                  = $text_color;
+$attributes['style']['elements']['link']['color']['text'] = $text_color;
+$inline_style_parts[] = 'color:' . $text_color . ';';
+}
+$class_names[] = 'has-text-color';
+$class_names[] = 'has-link-color';
+}
+
+$inline_style = implode( '', array_filter( $inline_style_parts ) );
+
+$wrapper_classes = implode( ' ', array_unique( array_filter( $class_names ) ) );
+$div_attributes  = '' !== $custom_id ? ' id="' . esc_attr( $custom_id ) . '"' : '';
+$div_attributes .= $wrapper_classes ? ' class="' . esc_attr( $wrapper_classes ) . '"' : '';
+$div_attributes .= '' !== $inline_style ? ' style="' . esc_attr( $inline_style ) . '"' : '';
+
+$inner_markup = sprintf( '<div%s>%s</div>', $div_attributes, wp_kses_post( $content ) );
+
+if ( '' !== $custom_css ) {
+Style_Parser::save_custom_css( $custom_css );
+}
+
+return Block_Builder::build( 'core/html', $attributes, $inner_markup );
+}
+
+/**
+ * Determine if a color value refers to a preset slug.
+ *
+ * @param string $color Color value.
+ */
+private function is_preset_color_slug( string $color ): bool {
+return '' !== $color && false === strpos( $color, '#' );
+}
 }

--- a/tests/ConversionSmokeTest.php
+++ b/tests/ConversionSmokeTest.php
@@ -1,0 +1,172 @@
+<?php
+// Minimal WordPress function stubs for testing.
+if ( ! function_exists( 'esc_attr' ) ) {
+function esc_attr( $text ) {
+return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+}
+}
+if ( ! function_exists( 'esc_url' ) ) {
+function esc_url( $url ) {
+return filter_var( $url, FILTER_SANITIZE_URL );
+}
+}
+if ( ! function_exists( 'esc_url_raw' ) ) {
+function esc_url_raw( $url ) {
+return filter_var( $url, FILTER_SANITIZE_URL );
+}
+}
+if ( ! function_exists( 'esc_html' ) ) {
+function esc_html( $text ) {
+return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+}
+}
+if ( ! function_exists( 'esc_html__' ) ) {
+function esc_html__( $text, $domain = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+return $text;
+}
+}
+if ( ! function_exists( 'sanitize_html_class' ) ) {
+function sanitize_html_class( $class ) {
+return preg_replace( '/[^A-Za-z0-9_-]/', '', (string) $class );
+}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+function wp_json_encode( $data ) {
+return json_encode( $data );
+}
+}
+if ( ! function_exists( 'wp_kses_post' ) ) {
+function wp_kses_post( $content ) {
+return (string) $content;
+}
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+function sanitize_text_field( $text ) {
+return trim( (string) $text );
+}
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+function sanitize_key( $key ) {
+return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+}
+}
+if ( ! function_exists( 'wp_get_custom_css_post' ) ) {
+function wp_get_custom_css_post() {
+return (object) array( 'post_content' => '' );
+}
+}
+if ( ! function_exists( 'wp_update_custom_css_post' ) ) {
+function wp_update_custom_css_post( $css ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+return true;
+}
+}
+
+echo "Running conversion smoke tests...\n";
+
+if ( ! defined( 'ABSPATH' ) ) {
+define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../src/admin/helper/class-style-parser.php';
+require_once __DIR__ . '/../src/admin/helper/class-block-builder.php';
+require_once __DIR__ . '/../src/admin/layout/class-container-classifier.php';
+require_once __DIR__ . '/../src/admin/class-widget-handler-interface.php';
+require_once __DIR__ . '/../src/admin/class-widget-handler-factory.php';
+require_once __DIR__ . '/../src/admin/widget/class-heading-widget-handler.php';
+require_once __DIR__ . '/../src/admin/widget/class-text-editor-widget-handler.php';
+require_once __DIR__ . '/../src/admin/widget/class-button-widget-handler.php';
+require_once __DIR__ . '/../src/admin/widget/class-image-widget-handler.php';
+require_once __DIR__ . '/../src/admin/helper/class-file-upload-service.php';
+require_once __DIR__ . '/../src/admin/class-admin-settings.php';
+
+use Progressus\Gutenberg\Admin\Admin_Settings;
+
+class Test_Admin_Settings extends Admin_Settings {
+public function __construct() {}
+}
+
+$converter = new Test_Admin_Settings();
+
+/**
+ * Simple assertion helper.
+ *
+ * @param bool   $condition Assertion condition.
+ * @param string $message   Failure message.
+ */
+function expect_true( bool $condition, string $message ): void {
+if ( ! $condition ) {
+throw new RuntimeException( $message );
+}
+}
+
+$simple_grid = array(
+array(
+'elType'   => 'container',
+'settings' => array(
+'container_type'     => 'grid',
+'grid_columns_grid'  => array( 'size' => 3 ),
+),
+'elements' => array(
+array(
+'elType'     => 'widget',
+'widgetType' => 'heading',
+'settings'   => array(
+'title'       => 'Grid Heading',
+'header_size' => 'h2',
+),
+),
+array(
+'elType'     => 'widget',
+'widgetType' => 'image',
+'settings'   => array(
+'image' => array(
+'url' => 'https://example.com/image.jpg',
+'alt' => 'Example',
+),
+),
+),
+array(
+'elType'     => 'widget',
+'widgetType' => 'button',
+'settings'   => array(
+'text' => 'Click me',
+'link' => array( 'url' => 'https://example.com' ),
+),
+),
+),
+),
+);
+
+$simple_output = $converter->parse_elementor_elements( $simple_grid );
+expect_true( str_contains( $simple_output, '<!-- wp:core/group {"layout":{"type":"grid","columnCount":3}} -->' ), 'Expected grid group layout comment missing.' );
+expect_true( str_contains( $simple_output, '<!-- wp:core/heading' ), 'Heading block missing from simple grid.' );
+expect_true( str_contains( $simple_output, '<!-- wp:core/image' ), 'Image block missing from simple grid.' );
+expect_true( str_contains( $simple_output, '<!-- wp:core/buttons' ), 'Buttons block missing from simple grid.' );
+
+$complex_grid = array(
+array(
+'elType'   => 'container',
+'settings' => array(
+'grid_template_columns' => 'repeat(3, 1fr)',
+),
+'elements' => array_map(
+static function ( $index ) {
+return array(
+'elType'     => 'widget',
+'widgetType' => 'heading',
+'settings'   => array(
+'title'       => 'Item ' . $index,
+'header_size' => 'h3',
+),
+);
+},
+range( 1, 5 )
+),
+),
+);
+
+$complex_output = $converter->parse_elementor_elements( $complex_grid );
+expect_true( str_contains( $complex_output, '"layout":{"type":"grid","columnCount":3}' ), 'Grid column count not detected for complex grid.' );
+expect_true( substr_count( $complex_output, '<!-- wp:core/heading' ) === 5, 'Expected five heading blocks in complex grid.' );
+
+echo "All conversion smoke tests passed\n";


### PR DESCRIPTION
## Summary
- classify Elementor containers as grid, flex row, or constrained groups and render them through Block_Builder
- harden style parsing and widget handlers so headings, text, buttons, and images map cleanly to core blocks without undefined index notices
- add smoke tests that exercise simple and complex grid layouts to verify the generated block markup

## Testing
- php tests/ConversionSmokeTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e5a4d6524c832fadaa5d099975662a